### PR TITLE
mapistore: Bypass Embedded message creation for Tasks in Outlook

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -1591,6 +1591,10 @@ _PUBLIC_ enum mapistore_error mapistore_message_attachment_create_embedded_messa
 	backend_ctx = mapistore_backend_lookup(mstore_ctx->context_list, context_id);
 	MAPISTORE_RETVAL_IF(!backend_ctx, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
 
+	if (strstr(backend_ctx->uri, "@tasks") != NULL) {
+		return MAPI_E_NOT_IMPLEMENTED;
+	}
+
 	/* Step 2. Call backend operation */
 	return mapistore_backend_message_attachment_create_embedded_message(backend_ctx, attachment, mem_ctx, embedded_message, msg);
 }


### PR DESCRIPTION
Right now SOGo back end doesn't support embedded messages in
a Task, which leads to a nasty runtime Obj-C exception.
This effectively kills openchange process, so it is better
we just return MAPI_E_NOT_IMPLEMENTED for such objects and continue
to work instead of breaking badly.

This is a temporary fix for: issues => 7345

Signed-off-by: Kamen Mazdrashki kamenim@samba.org
