### PR TITLE
Revert "oxcmsg: Implementation for partial UserDNs in ModifyRecipients call

### DIFF
--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -1626,7 +1626,6 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 	}
 
 	*dnprefix = '\0';
-	emsmdbp_ctx->szDNPrefix = talloc_strdup(emsmdbp_ctx, userDN);
 	*r->out.szDNPrefix = strupper_talloc(mem_ctx, userDN);
 
 	/* Step 6. Fill EcDoConnectEx reply */

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -50,7 +50,6 @@ struct emsmdbp_context {
 	char					*szDisplayName;
 	uint32_t				userLanguage;
 	char					*username;
-	char					*szDNPrefix;
 	struct loadparm_context			*lp_ctx;
 	struct ldb_context			*oc_ctx;
 	struct ldb_context			*samdb_ctx;

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -698,10 +698,7 @@ end:
 	return MAPI_E_SUCCESS;
 }
 
-static enum MAPISTATUS oxcmsg_parse_ModifyRecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context *emsmdbp_ctx,
-						       struct ModifyRecipientRow *recipient_row,
-						       uint16_t prop_count, enum MAPITAGS *properties,
-						       struct mapistore_message_recipient *recipient)
+static void oxcmsg_parse_ModifyRecipientRow(TALLOC_CTX *mem_ctx, struct ModifyRecipientRow *recipient_row, uint16_t prop_count, enum MAPITAGS *properties, struct mapistore_message_recipient *recipient)
 {
 	int			i, data_pos;
 	uint8_t			*src_value;
@@ -715,29 +712,11 @@ static enum MAPISTATUS oxcmsg_parse_ModifyRecipientRow(TALLOC_CTX *mem_ctx, stru
 
 	recipient->type = recipient_row->RecipClass;
 
-	recipient->username = NULL;
 	if ((recipient_row->RecipientRow.RecipientFlags & 0x07) == 1) {
-		if (recipient_row->RecipientRow.AddressPrefixUsed.prefix_size != 0) {
-			/* sanity check for DNPrefix valid length */
-			OPENCHANGE_RETVAL_IF(!emsmdbp_ctx->szDNPrefix, MAPI_E_INVALID_PARAMETER, NULL);
-			if (recipient_row->RecipientRow.AddressPrefixUsed.prefix_size > strlen(emsmdbp_ctx->szDNPrefix)) {
-				DEBUG(0, ("Requested x500name prefix is beyond what we have for DNPrefix=[%s]\n",
-						emsmdbp_ctx->szDNPrefix));
-				return MAPI_E_INVALID_PARAMETER;
-			}
-
-			/* concatenate x500name suffix with szDNPrefix we are using at the moment */
-			size_t name_len = recipient_row->RecipientRow.AddressPrefixUsed.prefix_size
-					+ strlen(recipient_row->RecipientRow.X500DN.recipient_x500name) + 1;
-			recipient->username = talloc_zero_array(mem_ctx, char, name_len);
-			OPENCHANGE_RETVAL_IF(!recipient->username, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
-
-			strncpy(recipient->username, emsmdbp_ctx->szDNPrefix, recipient_row->RecipientRow.AddressPrefixUsed.prefix_size);
-			strcpy(recipient->username + recipient_row->RecipientRow.AddressPrefixUsed.prefix_size,
-					recipient_row->RecipientRow.X500DN.recipient_x500name);
-		} else {
-			recipient->username = (char *) recipient_row->RecipientRow.X500DN.recipient_x500name;
-		}
+		recipient->username = (char *) recipient_row->RecipientRow.X500DN.recipient_x500name;
+	}
+	else {
+		recipient->username = NULL;
 	}
 
 	recipient->data = talloc_array(mem_ctx, void *, prop_count + 2);
@@ -838,8 +817,6 @@ static enum MAPISTATUS oxcmsg_parse_ModifyRecipientRow(TALLOC_CTX *mem_ctx, stru
 		recipient->data[i+2] = dest_value;
 		data_pos += value_size;
 	}
-
-	return MAPI_E_SUCCESS;
 }
 
 /**
@@ -915,16 +892,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopModifyRecipients(TALLOC_CTX *mem_ctx,
 
 		recipients = talloc_array(mem_ctx, struct mapistore_message_recipient, mapi_req->u.mapi_ModifyRecipients.cValues);
 		for (i = 0; i < mapi_req->u.mapi_ModifyRecipients.cValues; i++) {
-			retval = oxcmsg_parse_ModifyRecipientRow(recipients, emsmdbp_ctx,
-								 mapi_req->u.mapi_ModifyRecipients.RecipientRow + i,
-								 mapi_req->u.mapi_ModifyRecipients.prop_count,
-								 mapi_req->u.mapi_ModifyRecipients.properties,
-								 recipients + i);
-			if (retval != MAPI_E_SUCCESS) {
-				DEBUG(0, ("Failed to parse RecipientRow. [%s]\n", mapi_get_errstr(retval)));
-				mapi_repl->error_code = retval;
-				goto end;
-			}
+			oxcmsg_parse_ModifyRecipientRow(recipients, mapi_req->u.mapi_ModifyRecipients.RecipientRow + i, mapi_req->u.mapi_ModifyRecipients.prop_count, mapi_req->u.mapi_ModifyRecipients.properties, recipients + i);
 		}
 		mapistore_message_modify_recipients(emsmdbp_ctx->mstore_ctx, contextID, object->backend_object, columns, mapi_req->u.mapi_ModifyRecipients.cValues, recipients);
 	}


### PR DESCRIPTION
This reverts commit ea9cf1980a13786ecdf17e710eaf256bee5f1152.

Unfortunately this commit brakes SOGo backend expectations that
recipient->username actually holds samAccountName for the user.
Thus although Openchange layer is doing the right thing now,
SOGo is not handling this very well. I need to work more on that.
Sorry for faulty commit
