### PR TITLE
mapistore/backend_get_path: Check return value from backend.get_path for != NULL

### DIFF
--- a/mapiproxy/libmapistore/mapistore_backend.c
+++ b/mapiproxy/libmapistore/mapistore_backend.c
@@ -523,7 +523,11 @@ enum mapistore_error mapistore_backend_get_path(struct backend_context *bctx, TA
 
 	ret = bctx->backend->context.get_path(bctx->backend_object, mem_ctx, fmid, &bpath);
 
-	if (!ret) {
+	if (ret == MAPISTORE_SUCCESS) {
+		if (!bpath) {
+			DEBUG(3, ("%s: Mapistore backend return SUCCESS, but path url is NULL\n", __location__));
+			return MAPISTORE_ERR_INVALID_DATA;
+		}
 		*path = talloc_asprintf(mem_ctx, "%s%s", bctx->backend->backend.namespace, bpath);
 	} else {
 		*path = NULL;


### PR DESCRIPTION
Backend may return MAPISTORE_SUCCESS and dbpath = NULL, in which
case are going to make a fake url like:
  sogo://(null)
Such broken URLs quickly polute both indexing and openchangedb databases.
