### PR TITLE
Install upload-crash-report.py along with openchangeserver

### DIFF
--- a/debian/openchangeserver.install
+++ b/debian/openchangeserver.install
@@ -4,6 +4,7 @@ usr/sbin/openchange_newuser
 usr/sbin/openchange_provision
 usr/share/samba/setup/AD/*.ldif
 usr/share/samba/setup/AD/prefixMap.txt
+usr/share/openchange/upload-crash-report.py
 usr/share/openchange/setup/openchangedb/openchangedb_schema.sql
 usr/lib/python*/dist-packages/openchange/*.py
 usr/lib/python*/dist-packages/openchange/web/*.py

--- a/debian/rules
+++ b/debian/rules
@@ -60,6 +60,7 @@ override_dh_auto_install:
 	mv $(DESTDIR)/usr/lib/$(DEB_HOST_MULTIARCH)/nagios/check_exchange \
 	   $(DESTDIR)/usr/lib/nagios/plugins/check_exchange 
 	install -m 700 -d -o www-data -g www-data $(DESTDIR)/var/cache/ntlmauthhandler
+	install -m 0755 script/bug-analysis/upload-crash-report.py $(DESTDIR)/usr/share/openchange/
 	rm -rf $(DESTDIR)/usr/modules
 	# Don't install the testsuite for now
 	rm -f $(DESTDIR)/usr/torture/openchange.so


### PR DESCRIPTION
Merge it once https://github.com/openchange/openchange/pull/68 is merged into zentyal/openchange trusty branch to have this file.
