### PR TITLE
Escape ldap filters with strings properly

### DIFF
--- a/mapiproxy/libmapiproxy/openchangedb.c
+++ b/mapiproxy/libmapiproxy/openchangedb.c
@@ -67,7 +67,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_SystemFolderID(struct ldb_context *ldb
 
 	/* Step 1. Search Mailbox Root DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -242,7 +242,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_MailboxGuid(struct ldb_context *ldb_ct
 
 	/* Step 1. Search Mailbox DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	
 	/* Step 2. Retrieve MailboxGUID attribute's value */
@@ -286,7 +286,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_MailboxReplica(struct ldb_context *ldb
 
 	/* Step 1. Search Mailbox DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -514,13 +514,13 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_fid(struct ldb_context *ldb_ctx, const
 	mem_ctx = talloc_named(NULL, 0, "openchangedb_get_fid");
 
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", mapistoreURL);
+			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", ldb_binary_encode_string(mem_ctx, mapistoreURL));
 	if (ret != LDB_SUCCESS || !res->count) {
 		len = strlen(mapistoreURL);
 		if (mapistoreURL[len-1] == '/') {
 			slashLessURL = talloc_strdup(mem_ctx, mapistoreURL);
 			slashLessURL[len-1] = 0;
-			ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx), LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", slashLessURL);
+			ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx), LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", ldb_binary_encode_string(mem_ctx, slashLessURL));
 		}
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	}
@@ -557,7 +557,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_MAPIStoreURIs(struct ldb_context *ldb_
 
 	/* fetch mailbox DN */
 	ret = ldb_search(ldb_ctx, local_mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(&(cn=%s)(MailboxGUID=*))", username);
+			 LDB_SCOPE_SUBTREE, attrs, "(&(cn=%s)(MailboxGUID=*))", ldb_binary_encode_string(mem_ctx, username));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, local_mem_ctx);
 
 	dnstr = talloc_strdup(local_mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -626,7 +626,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_ReceiveFolder(TALLOC_CTX *parent_ctx,
 
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	dnstr = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -717,7 +717,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_TransportFolder(struct ldb_context *ld
 
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	dnstr = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -1600,7 +1600,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_fid_by_name(struct ldb_context *ldb_ct
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
 			 LDB_SCOPE_SUBTREE, attrs,
 			 "(&(PidTagParentFolderId=%"PRIu64")(PidTagDisplayName=%s))",
-			 parent_fid, foldername);
+			 parent_fid, ldb_binary_encode_string(mem_ctx, foldername));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -1644,7 +1644,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_mid_by_subject(struct ldb_context *ldb
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, base_dn,
 			 LDB_SCOPE_SUBTREE, attrs,
 			 "(&(PidTagParentFolderId=%"PRIu64")(PidTagNormalizedSubject=%s))",
-			 parent_fid, subject);
+			 parent_fid, ldb_binary_encode_string(mem_ctx, subject));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -1718,7 +1718,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_set_ReceiveFolder(struct ldb_context *ldb_
 	
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	dnstr = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -1733,7 +1733,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_set_ReceiveFolder(struct ldb_context *ldb_
 
 	/* Step 2. Search for the MessageClass within user's mailbox */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, dn, LDB_SCOPE_SUBTREE, attrs, 
-			 "(PidTagMessageClass=%s)", MessageClass);
+			 "(PidTagMessageClass=%s)", ldb_binary_encode_string(mem_ctx, MessageClass));
 	DEBUG(5, ("openchangedb_get_ReceiveFolder, res->count: %i\n", res->count));
 
 	/* We should never have more than one record with a specific MessageClass */
@@ -1809,7 +1809,8 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_fid_from_partial_uri(struct ldb_contex
 
 	/* Search mapistoreURI given partial URI */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", partialURI);
+			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)",
+			 ldb_binary_encode_string(mem_ctx, partialURI));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	OPENCHANGE_RETVAL_IF(res->count > 1, MAPI_E_COLLISION, mem_ctx);
@@ -1863,7 +1864,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_users_from_partial_uri(TALLOC_CTX *par
 		/* Retrieve the system user name */
 		mailboxDN = ldb_msg_find_attr_as_string(res->msgs[i], "mailboxDN", NULL);
 		dn = ldb_dn_new(mem_ctx, ldb_ctx, mailboxDN);
-		ret = ldb_search(ldb_ctx, mem_ctx, &mres, dn, LDB_SCOPE_SUBTREE, attrs, "(distinguishedName=%s)", mailboxDN);
+		ret = ldb_search(ldb_ctx, mem_ctx, &mres, dn, LDB_SCOPE_SUBTREE, attrs, "(distinguishedName=%s)", ldb_binary_encode_string(mem_ctx, mailboxDN));
 		/* This should NEVER happen */
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 		tmp = ldb_msg_find_attr_as_string(mres->msgs[0], "cn", NULL);
@@ -2088,7 +2089,8 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_message_count(struct ldb_context *ldb_
 	objectClass = (fai ? "faiMessage" : "systemMessage");
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
 			 LDB_SCOPE_SUBTREE, attrs, 
-			 "(&(objectClass=%s)(PidTagParentFolderId=%"PRIu64"))", objectClass, fid);
+			 "(&(objectClass=%s)(PidTagParentFolderId=%"PRIu64"))",
+			 ldb_binary_encode_string(mem_ctx, objectClass), fid);
 	printf("ldb error: %s\n", ldb_errstring(ldb_ctx));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 	

--- a/mapiproxy/libmapiproxy/openchangedb_table.c
+++ b/mapiproxy/libmapiproxy/openchangedb_table.c
@@ -199,10 +199,10 @@ static char *openchangedb_table_build_filter(TALLOC_CTX *mem_ctx, struct opencha
 			filter = talloc_asprintf_append(filter, "(%s=", PidTagAttr);
 			switch (restrictions->res.resProperty.ulPropTag & 0xFFFF) {
 			case PT_STRING8:
-				filter = talloc_asprintf_append(filter, "%s)", restrictions->res.resProperty.lpProp.value.lpszA);
+				filter = talloc_asprintf_append(filter, "%s)", ldb_binary_encode_string(filter, restrictions->res.resProperty.lpProp.value.lpszA));
 				break;
 			case PT_UNICODE:
-				filter = talloc_asprintf_append(filter, "%s)", restrictions->res.resProperty.lpProp.value.lpszW);
+				filter = talloc_asprintf_append(filter, "%s)", ldb_binary_encode_string(filter, restrictions->res.resProperty.lpProp.value.lpszW));
 				break;
 			default:
 				DEBUG(0, ("Unsupported RES_PROPERTY property type: 0x%.4x\n", (restrictions->res.resProperty.ulPropTag & 0xFFFF)));

--- a/mapiproxy/libmapistore/mapistore_namedprops.c
+++ b/mapiproxy/libmapistore/mapistore_namedprops.c
@@ -276,7 +276,7 @@ _PUBLIC_ enum mapistore_error mapistore_namedprops_get_mapped_id(struct ldb_cont
 		break;
 	case MNID_STRING:
 		filter = talloc_asprintf(mem_ctx, "(&(objectClass=MNID_STRING)(oleguid=%s)(cn=%s))",
-					 guid, nameid.kind.lpwstr.Name);
+					 guid, ldb_binary_encode_string(mem_ctx, nameid.kind.lpwstr.Name));
 		break;
 	}
 	talloc_free(guid);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -218,7 +218,7 @@ _PUBLIC_ bool emsmdbp_verify_user(struct dcesrv_call_state *dce_call,
 
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s", username);
+			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s", ldb_binary_encode_string(emsmdbp_ctx, username));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -274,7 +274,7 @@ _PUBLIC_ bool emsmdbp_verify_userdn(struct dcesrv_call_state *dce_call,
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 legacyExchangeDN);
+			 ldb_binary_encode_string(emsmdbp_ctx, legacyExchangeDN));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -342,7 +342,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs,
 			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 recipient);
+			 ldb_binary_encode_string(emsmdbp_ctx, recipient));
 
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1093,7 +1093,7 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *mem_ctx,
 		ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
 				 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 				 LDB_SCOPE_SUBTREE, recipient_attrs, "legacyExchangeDN=%s", 
-				 object->object.mailbox->owner_EssDN);
+				 ldb_binary_encode_string(mem_ctx, object->object.mailbox->owner_EssDN));
 		if (!ret && res->count == 1) {
 			accountName = ldb_msg_find_attr_as_string(res->msgs[0], "sAMAccountName", NULL);
 			if (accountName) {

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -65,7 +65,7 @@ static void oxcmsg_fill_RecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs,
 			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 recipient->username);
+			 ldb_binary_encode_string(emsmdbp_ctx, recipient->username));
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {
 		DEBUG(0, ("record not found for %s\n", recipient->username));

--- a/mapiproxy/servers/default/emsmdb/oxcstor.c
+++ b/mapiproxy/servers/default/emsmdb/oxcstor.c
@@ -65,7 +65,7 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!request->EssDN, MAPI_E_INVALID_PARAMETER, NULL);
 
 	/* Step 0. Retrieve user record */
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", request->EssDN);
+	ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", ldb_binary_encode_string(mem_ctx, request->EssDN));
 	OPENCHANGE_RETVAL_IF((ret || res->count != 1), ecUnknownUser, NULL);
 
 	/* Step 1. Retrieve username from record */

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -1113,7 +1113,7 @@ static void dcesrv_NspiResolveNames(struct dcesrv_call_state *dce_call,
 
 		/* Build search filter */
 		for (j = 0; j < ARRAY_SIZE(search_attr); j++) {
-			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], paStr->Strings[i]);
+			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], ldb_binary_encode_string(mem_ctx, paStr->Strings[i]));
 			filter = talloc_strdup_append(filter, attr_filter);
 			talloc_free(attr_filter);
 		}
@@ -1229,7 +1229,7 @@ static void dcesrv_NspiResolveNamesW(struct dcesrv_call_state *dce_call,
 
 		/* Build search filter */
 		for (j = 0; j < ARRAY_SIZE(search_attr); j++) {
-			char	*attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], paWStr->Strings[i]);
+			char	*attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], ldb_binary_encode_string(mem_ctx, paWStr->Strings[i]));
 			filter = talloc_strdup_append(filter, attr_filter);
 			talloc_free(attr_filter);
 		}

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -137,7 +137,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_account_info(TALLOC_CTX *mem_ctx,
 	ret = ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
 			 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
-			 username);
+			 ldb_binary_encode_string(mem_ctx, username));
 	OPENCHANGE_RETVAL_IF((ret != LDB_SUCCESS || !res->count), MAPI_E_NOT_FOUND, NULL);
 
 	/* Check if more than one record was found */
@@ -1086,6 +1086,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_search(TALLOC_CTX *mem_ctx, struct emsabp_contex
 		if (attr == NULL) {
 			return MAPI_E_NO_SUPPORT;
 		}
+		attr = ldb_binary_encode_string(mem_ctx, attr);
 
 		/* Special case: anr doesn't return correct result with partial search */
 		if (!strcmp(fmt_attr, "anr")) {
@@ -1204,14 +1205,14 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_legacyExchangeDN(struct emsabp_context *e
 	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 			 ldb_get_config_basedn(emsabp_ctx->samdb_ctx), 
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 legacyDN);
+			 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
 		*pbUseConfPartition = false;
 		ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 				 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 				 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-				 legacyDN);
+				 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 	}
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, NULL);
 


### PR DESCRIPTION
Ldap filters with chars in `*()\&|!"` are wrong and we have to encode it.
