### PR TITLE
ndr:  fixes for string8 data which contains no-ascii characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Do not assume that string8 variables have ascii encoding
 * Support notifications when the username is different from mail address (e.g. user bob with bobby@domain.com as his email)
 * Telephone and location fields are now shown in the Global Address List
 * Rpcproxy handles client disconnections better

--- a/exchange.idl
+++ b/exchange.idl
@@ -56,9 +56,9 @@ cpp_quote("#include <gen_ndr/ndr_misc.h>")
 	/* Function 0x00 */
 	MAPISTATUS RfrGetNewDSA(
 		[in]                                    uint32  ulFlags,
-		[in,string,charset(DOS)]                uint8   *pUserDN,
-		[in,out,unique,string,charset(DOS)]     uint8   **ppszUnused,
-		[in,out,unique,string,charset(DOS)]     uint8   **ppszServer
+		[in,string]                uint8   *pUserDN,
+		[in,out,unique,string]     uint8   **ppszUnused,
+		[in,out,unique,string]     uint8   **ppszServer
 		);
 
 	/*****************/
@@ -66,8 +66,8 @@ cpp_quote("#include <gen_ndr/ndr_misc.h>")
 	MAPISTATUS RfrGetFQDNFromLegacyDN(
 		[in]							uint32	ulFlags,
 		[in,range(10,1024)]					uint32	cbMailboxServerDN,
-		[in,string,charset(DOS),size_is(cbMailboxServerDN)]	uint8	*szMailboxServerDN,
-		[out,ref,string,charset(DOS)]				uint8	**ppszServerFQDN
+		[in,string,size_is(cbMailboxServerDN)]	uint8	*szMailboxServerDN,
+		[out,ref,string]				uint8	**ppszServerFQDN
 		);
 }
 
@@ -271,12 +271,12 @@ System Attendant Private Interface
 
 	typedef struct {
 		[range(0,100000)] uint32			cValues;
-		[string,size_is(cValues),charset(DOS)] uint8	**lppszA;
+		[string,size_is(cValues)] uint8	**lppszA;
 	} StringArray_r;
 
 	typedef struct {
 		[range(0,100000)] uint32		       	Count;
-		[string,size_is(Count),charset(DOS)] uint8     	*Strings[];
+		[string,size_is(Count)] uint8     	*Strings[];
 	} StringsArray_r;
 
 	typedef struct {
@@ -333,7 +333,7 @@ System Attendant Private Interface
 		[case(PT_I2)]			uint16			i;
 		[case(PT_LONG)]			uint32			l;
 		[case(PT_BOOLEAN)]		uint8			b;
-		[case(PT_STRING8)][unique][string,charset(DOS)] uint8	*lpszA;
+		[case(PT_STRING8)][unique][string] uint8	*lpszA;
 		[case(PT_UNICODE)][string,charset(UTF16)] uint16	*lpszW;
 		[case(PT_BINARY)]		Binary_r       		bin;
 		[case(PT_SVREID)]		Binary_r		bin;
@@ -476,7 +476,7 @@ System Attendant Private Interface
 		[case(PT_DOUBLE)]		double			dbl;
 		[case(PT_BOOLEAN)]		uint8			b;
 		[case(PT_I8)]			dlong			d;
-		[case(PT_STRING8)][unique][string,charset(DOS)] uint8	*lpszA;
+		[case(PT_STRING8)][unique][string] uint8	*lpszA;
 		[case(PT_BINARY)]		Binary_r       		bin;
 		[case(PT_SVREID)]		Binary_r		bin;
 		[case(PT_UNICODE)][string,charset(UTF16)] uint16	*lpszW;
@@ -677,7 +677,7 @@ System Attendant Private Interface
 		[in] policy_handle			*handle,
 		[in] TI_dwFlags				dwFlags,
 		[in] uint32				ulType,
-		[in,unique,string,charset(DOS)] uint8	*pDN,
+		[in,unique,string] uint8	*pDN,
 		[in] uint32				dwCodePage,
 		[in] uint32				dwLocaleID,
 		[out] PropertyRow_r			**ppData
@@ -777,7 +777,7 @@ System Attendant Private Interface
 
 	MAPISTATUS EcDoConnect(
  		[out]				policy_handle	*handle,
-                [in,string,charset(DOS)]	uint8		szUserDN[],
+                [in,string]	uint8		szUserDN[],
 		[in]				uint32		ulFlags,
 		[in]				uint32		ulConMod,
 		[in]				uint32		cbLimit,
@@ -790,8 +790,8 @@ System Attendant Private Interface
 		[out]				uint32		*pcRetry,
 		[out]				uint32		*pcmsRetryDelay,
 		[out]				uint32		*picxr,
-                [out,ref,string,charset(DOS)]uint8		**szDNPrefix,
-                [out,ref,string,charset(DOS)]uint8		**szDisplayName,
+                [out,ref,string]uint8		**szDNPrefix,
+                [out,ref,string]uint8		**szDisplayName,
                 [out]				uint16          rgwServerVersion[3],
 		[in,out]       			uint16          rgwClientVersion[3],
                 [in,out]			uint32		*pullTimeStamp
@@ -4644,7 +4644,7 @@ System Attendant Private Interface
 
 	[public,nopull,nopush,noprint] MAPISTATUS EcDoConnectEx(
 		[out]				policy_handle				*handle,
-		[in,string,charset(DOS)]	uint8					szUserDN[],
+		[in,string]	uint8					szUserDN[],
 		[in]				uint32					ulFlags,
 		[in]				uint32					ulConMod,
 		[in]				uint32					cbLimit,
@@ -4657,8 +4657,8 @@ System Attendant Private Interface
 		[out]				uint32					*pcRetry,
 		[out]				uint32					*pcmsRetryDelay,
 		[out]				uint32					*picxr,
-		[out,ref,string,charset(DOS)]uint8					**szDNPrefix,
-		[out,ref,string,charset(DOS)]uint8					**szDisplayName,
+		[out,ref,string]	uint8					**szDNPrefix,
+		[out,ref,string]	uint8					**szDisplayName,
 		[in]				uint16					rgwClientVersion[3],
 		[out]				uint16					rgwServerVersion[3],
 		[out]				uint16					rgwBestVersion[3],
@@ -4726,4 +4726,3 @@ System Attendant Private Interface
 {
 	void unknown_dummy();
 }
-

--- a/libexchange2ical/exchange2ical_property.c
+++ b/libexchange2ical/exchange2ical_property.c
@@ -277,7 +277,7 @@ void ical_property_CATEGORIES(struct exchange2ical *exchange2ical)
 	if (!exchange2ical->Keywords->cValues) return;
 
 	for (i = 0; i < exchange2ical->Keywords->cValues; i++) {
-		prop = icalproperty_new_categories(exchange2ical->Keywords->lppszA[i]); 
+		prop = icalproperty_new_categories((const char *) exchange2ical->Keywords->lppszA[i]); 
 		icalcomponent_add_property(exchange2ical->vevent, prop);
 	}
 
@@ -306,7 +306,7 @@ void ical_property_CONTACT(struct exchange2ical *exchange2ical)
 	if (!exchange2ical->Contacts->cValues) return;
 
 	for (i = 0; i < exchange2ical->Contacts->cValues; i++) {
-		prop = icalproperty_new_contact(exchange2ical->Contacts->lppszA[i]);
+		prop = icalproperty_new_contact((const char *) exchange2ical->Contacts->lppszA[i]);
 		icalcomponent_add_property(exchange2ical->vevent, prop);
 	}
 }

--- a/libexchange2ical/ical2exchange_property.c
+++ b/libexchange2ical/ical2exchange_property.c
@@ -186,7 +186,7 @@ void ical2exchange_property_CATEGORIES(struct ical2exchange *ical2exchange)
 		categoriesProp = icalcomponent_get_next_property(ical2exchange->categoriesEvent, ICAL_CATEGORIES_PROPERTY);
 
 	}
-	sArray->lppszA= (const char **) stringArray;
+	sArray->lppszA= (uint8_t **) stringArray;
 	
  	/* SetProps */
  	ical2exchange->lpProps = add_SPropValue(ical2exchange->mem_ctx, ical2exchange->lpProps, &ical2exchange->cValues, PidNameKeywords, 
@@ -277,7 +277,7 @@ void ical2exchange_property_CONTACT(struct ical2exchange *ical2exchange)
 	}
 		
 	/*set up struct*/
-	sArray->lppszA=(const char **) stringArray;
+	sArray->lppszA=(uint8_t **) stringArray;
 
 	/* SetProps */
 	ical2exchange->lpProps = add_SPropValue(ical2exchange->mem_ctx, ical2exchange->lpProps, &ical2exchange->cValues, PidLidContacts, 

--- a/libmapi/IABContainer.c
+++ b/libmapi/IABContainer.c
@@ -327,8 +327,8 @@ _PUBLIC_ enum MAPISTATUS GetABRecipientInfo(struct mapi_session *session,
 
 	/* Step 2. Map recipient DN to MId */
 	pNames.Count = 0x1;
-	pNames.Strings = (const char **) talloc_array(mem_ctx, char *, 1);
-	pNames.Strings[0] = email;
+	pNames.Strings = (uint8_t **) talloc_array(mem_ctx, uint8_t *, 1);
+	pNames.Strings[0] = (uint8_t *) email;
 	pMId = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 	retval = nspi_DNToMId(nspi_ctx, mem_ctx, &pNames, &pMId);
 	MAPIFreeBuffer((char *)pNames.Strings[0]);

--- a/libmapi/IMAPISession.c
+++ b/libmapi/IMAPISession.c
@@ -56,8 +56,8 @@ static enum MAPISTATUS FindGoodServer(struct mapi_session *session,
 	if (server == false) {
 		/* Step 1. Retrieve a MID for our legacyDN */
 		pNames.Count = 0x1;
-		pNames.Strings = (const char **) talloc_array(mem_ctx, char *, 1);
-		pNames.Strings[0] = (const char *) talloc_strdup(pNames.Strings, legacyDN);
+		pNames.Strings = (uint8_t **) talloc_array(mem_ctx, uint8_t *, 1);
+		pNames.Strings[0] = (uint8_t *) talloc_strdup(pNames.Strings, legacyDN);
 
 		MId_array = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 		retval = nspi_DNToMId(nspi, mem_ctx, &pNames, &MId_array);
@@ -82,8 +82,8 @@ static enum MAPISTATUS FindGoodServer(struct mapi_session *session,
 
 	/* Step 3. Retrieve the MId for this server DN */
 	pNames.Count = 0x1;
-	pNames.Strings = (const char **) talloc_array(mem_ctx, char *, 1);
-	pNames.Strings[0] = (const char *) talloc_strdup(pNames.Strings, server_dn);
+	pNames.Strings = (uint8_t **) talloc_array(mem_ctx, uint8_t *, 1);
+	pNames.Strings[0] = (uint8_t *) talloc_strdup(pNames.Strings, server_dn);
 	MId_array = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 	retval = nspi_DNToMId(nspi, mem_ctx, &pNames, &MId_array);
 	MAPIFreeBuffer(pNames.Strings);
@@ -102,8 +102,8 @@ static enum MAPISTATUS FindGoodServer(struct mapi_session *session,
 	MVszA = (struct StringArray_r *) find_PropertyValue_data(&(PropertyRowSet->aRow[0]), PR_EMS_AB_NETWORK_ADDRESS);
 	OPENCHANGE_RETVAL_IF(!MVszA, MAPI_E_NOT_FOUND, mem_ctx);
 	for (i = 0; i != MVszA->cValues; i++) {
-		if (!strncasecmp(MVszA->lppszA[i], "ncacn_ip_tcp:", 13)) {
-			binding = MVszA->lppszA[i] + 13;
+		if (!strncasecmp((const char *) MVszA->lppszA[i], "ncacn_ip_tcp:", 13)) {
+			binding = (const char *) MVszA->lppszA[i] + 13;
 			break;
 		}
 	}

--- a/libmapi/IMSProvider.c
+++ b/libmapi/IMSProvider.c
@@ -169,9 +169,9 @@ _PUBLIC_ enum MAPISTATUS RfrGetNewDSA(struct mapi_context *mapi_ctx,
 
 
 	r.in.ulFlags = 0x0;
-	r.in.pUserDN = userDN ? userDN : "";
+	r.in.pUserDN = (uint8_t *) (userDN ? userDN : "");
 	r.in.ppszUnused = NULL;
-	r.in.ppszServer = (const char **) &ppszServer;
+	r.in.ppszServer = (uint8_t **) &ppszServer;
 
 	status = dcerpc_RfrGetNewDSA_r(pipe->binding_handle, mem_ctx, &r);
 	if ((!NT_STATUS_IS_OK(status) || !r.out.ppszServer || !*r.out.ppszServer) && server) {
@@ -230,8 +230,8 @@ _PUBLIC_ enum MAPISTATUS RfrGetFQDNFromLegacyDN(struct mapi_context *mapi_ctx, s
 
 	r.in.ulFlags = 0x0;
 	r.in.cbMailboxServerDN = strlen(profile->homemdb) + 1;
-	r.in.szMailboxServerDN = profile->homemdb;
-	r.out.ppszServerFQDN = &ppszServerFQDN;
+	r.in.szMailboxServerDN = (uint8_t *) profile->homemdb;
+	r.out.ppszServerFQDN = (uint8_t **) &ppszServerFQDN;
 
 	status = dcerpc_RfrGetFQDNFromLegacyDN_r(pipe->binding_handle, mem_ctx, &r);
 	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), MAPI_E_CALL_FAILED, mem_ctx);

--- a/libmapi/IMessage.c
+++ b/libmapi/IMessage.c
@@ -576,7 +576,7 @@ uint16_t mapi_recipients_RecipientFlags(struct SRow *aRow)
 	/* (Type) - 0x0 to 0x7: PR_ADDRTYPE */
 	lpProp = get_SPropValue_SRow(aRow, PR_ADDRTYPE);
 	if (lpProp && lpProp->value.lpszA) {
-		addrtype = lpProp->value.lpszA;
+		addrtype = (const char *) lpProp->value.lpszA;
 	} else {
 		lpProp = get_SPropValue_SRow(aRow, PR_ADDRTYPE_UNICODE);
 		if (lpProp && lpProp->value.lpszW) {
@@ -599,7 +599,7 @@ uint16_t mapi_recipients_RecipientFlags(struct SRow *aRow)
 	if (strcmp(addrtype, "EX")) {
 		lpProp = get_SPropValue_SRow(aRow, (unicode == true) ? PR_SMTP_ADDRESS_UNICODE: PR_SMTP_ADDRESS);
 		if (lpProp) {
-			tmp = (unicode == true) ? lpProp->value.lpszW : lpProp->value.lpszA;
+			tmp = (unicode == true) ? lpProp->value.lpszW : (const char *) lpProp->value.lpszA;
 			if (tmp) {
 				bitmask |= 0x8;
 			}
@@ -609,7 +609,7 @@ uint16_t mapi_recipients_RecipientFlags(struct SRow *aRow)
 	/* (D) - 0x10: PR_DISPLAY_NAME */
 	lpProp = get_SPropValue_SRow(aRow, (unicode == true) ? PR_DISPLAY_NAME_UNICODE : PR_DISPLAY_NAME);
 	if (lpProp) {
-		display_name = (unicode == true) ? lpProp->value.lpszW : lpProp->value.lpszA;
+		display_name = (unicode == true) ? lpProp->value.lpszW : (const char *) lpProp->value.lpszA;
 		if (display_name) {
 			bitmask |= 0x10;
 		}
@@ -618,7 +618,7 @@ uint16_t mapi_recipients_RecipientFlags(struct SRow *aRow)
 	/* (T) - 0x20: PR_TRANSMITTABLE_DISPLAY_NAME */
 	lpProp = get_SPropValue_SRow(aRow, (unicode == true) ? PR_TRANSMITTABLE_DISPLAY_NAME_UNICODE : PR_TRANSMITTABLE_DISPLAY_NAME);
 	if (lpProp) {
-		transmit_display_name = (unicode == true) ? lpProp->value.lpszW : lpProp->value.lpszA;
+		transmit_display_name =(unicode == true) ? lpProp->value.lpszW : (const char *) lpProp->value.lpszA;
 		if (transmit_display_name) {
 			if (!display_name) {
 				bitmask |= 0x20;
@@ -654,7 +654,7 @@ uint16_t mapi_recipients_RecipientFlags(struct SRow *aRow)
 	/* (I) - 0x400: PR_7BIT_DISPLAY_NAME */
 	lpProp = get_SPropValue_SRow(aRow, (unicode == true) ? PR_7BIT_DISPLAY_NAME_UNICODE : PR_7BIT_DISPLAY_NAME);
 	if (lpProp) {
-		tmp = (unicode == true) ? lpProp->value.lpszW : lpProp->value.lpszA;
+		tmp = (unicode == true) ? lpProp->value.lpszW : (const char *) lpProp->value.lpszA;
 		if (tmp) {
 			bitmask |= 0x400;
 		}

--- a/libmapi/IMsgStore.c
+++ b/libmapi/IMsgStore.c
@@ -555,11 +555,11 @@ _PUBLIC_ enum MAPISTATUS GetReceiveFolderTable(mapi_object_t *obj_store,
 		if (reply->entries[i].lpszMessageClass && strlen(reply->entries[i].lpszMessageClass)) {
 			SRowSet->aRow[i].lpProps[1].ulPropTag = PR_MESSAGE_CLASS;
 			SRowSet->aRow[i].lpProps[1].dwAlignPad = 0x0;
-			SRowSet->aRow[i].lpProps[1].value.lpszA = talloc_strdup((TALLOC_CTX *)SRowSet->aRow[i].lpProps, reply->entries[i].lpszMessageClass);
+			SRowSet->aRow[i].lpProps[1].value.lpszA = (uint8_t *) talloc_strdup((TALLOC_CTX *)SRowSet->aRow[i].lpProps, reply->entries[i].lpszMessageClass);
 		} else {
 			SRowSet->aRow[i].lpProps[1].ulPropTag = PR_MESSAGE_CLASS;
 			SRowSet->aRow[i].lpProps[1].dwAlignPad = 0x0;
-			SRowSet->aRow[i].lpProps[1].value.lpszA = "";
+			SRowSet->aRow[i].lpProps[1].value.lpszA =  (uint8_t *) "";
 		}
 
 		SRowSet->aRow[i].lpProps[2].ulPropTag = PR_LAST_MODIFICATION_TIME;

--- a/libmapi/emsmdb.c
+++ b/libmapi/emsmdb.c
@@ -106,9 +106,9 @@ struct emsmdb_context *emsmdb_connect(TALLOC_CTX *parent_mem_ctx,
 	ret->info.szDisplayName = NULL;
 	ret->info.szDNPrefix = NULL;
 
-	r.in.szUserDN = session->profile->mailbox;
+	r.in.szUserDN = (uint8_t *) session->profile->mailbox;
 	r.in.ulFlags = 0x00000000;
-	r.in.ulConMod = emsmdb_hash(r.in.szUserDN);
+	r.in.ulConMod = emsmdb_hash((char *) r.in.szUserDN);
 	r.in.cbLimit = 0x00000000;
 	r.in.ulCpid = session->profile->codepage;
 	r.in.ulLcidString = session->profile->language;
@@ -120,8 +120,8 @@ struct emsmdb_context *emsmdb_connect(TALLOC_CTX *parent_mem_ctx,
 	r.in.rgwClientVersion[2] = 0x03e8;
 	r.in.pullTimeStamp = &pullTimeStamp;
 
-	r.out.szDNPrefix = (const char **)&ret->info.szDNPrefix;
-	r.out.szDisplayName = (const char **)&ret->info.szDisplayName;
+	r.out.szDNPrefix = (uint8_t **)&ret->info.szDNPrefix;
+	r.out.szDisplayName = (uint8_t **)&ret->info.szDisplayName;
 	r.out.handle = &ret->handle;
 	r.out.pcmsPollsMax = &ret->info.pcmsPollsMax;
 	r.out.pcRetry = &ret->info.pcRetry;
@@ -200,9 +200,9 @@ struct emsmdb_context *emsmdb_connect_ex(TALLOC_CTX *mem_ctx,
 	
 	r.out.handle = &ctx->handle;
 
-	r.in.szUserDN = session->profile->mailbox;
+	r.in.szUserDN = (uint8_t *) session->profile->mailbox;
 	r.in.ulFlags = 0x00000000;
-	r.in.ulConMod = emsmdb_hash(r.in.szUserDN);
+	r.in.ulConMod = emsmdb_hash((char *) r.in.szUserDN);
 	r.in.cbLimit = 0x00000000;
 	r.in.ulCpid = session->profile->codepage;
 	r.in.ulLcidString = session->profile->language;
@@ -210,8 +210,8 @@ struct emsmdb_context *emsmdb_connect_ex(TALLOC_CTX *mem_ctx,
 	r.in.ulIcxrLink = 0xFFFFFFFF;
 	r.in.usFCanConvertCodePages = 0x1;
 
-	r.out.szDNPrefix = (const char **) &ctx->info.szDNPrefix;
-	r.out.szDisplayName = (const char **) &ctx->info.szDisplayName;
+	r.out.szDNPrefix = (uint8_t **) &ctx->info.szDNPrefix;
+	r.out.szDisplayName = (uint8_t **) &ctx->info.szDisplayName;
 	r.out.pcmsPollsMax = &ctx->info.pcmsPollsMax;
 	r.out.pcRetry = &ctx->info.pcRetry;
 	r.out.pcmsRetryDelay = &ctx->info.pcmsRetryDelay;
@@ -915,9 +915,9 @@ const void *pull_emsmdb_property(TALLOC_CTX *mem_ctx,
 		*offset = ndr->offset;
 		slpstr = talloc_zero(mem_ctx, struct StringArray_r);
 		slpstr->cValues = pt_slpstr.cValues;
-		slpstr->lppszA = talloc_array(mem_ctx, const char *, pt_slpstr.cValues);
+		slpstr->lppszA = talloc_array(mem_ctx, uint8_t *, pt_slpstr.cValues);
 		for (i = 0; i < slpstr->cValues; i++) {
-			slpstr->lppszA[i] = talloc_strdup(mem_ctx, pt_slpstr.strings[i].lppszA);
+			slpstr->lppszA[i] = (uint8_t *) talloc_strdup(mem_ctx, pt_slpstr.strings[i].lppszA);
 		}
 		talloc_free(ndr);
 		return (const void *) slpstr;

--- a/libmapi/fxparser.c
+++ b/libmapi/fxparser.c
@@ -338,7 +338,7 @@ static bool fetch_property_value(struct fx_parser_context *parser, DATA_BLOB *bu
 		char *str = NULL;
 		if (!pull_string8(parser, &str))
 			return false;
-		prop->value.lpszA = str;
+		prop->value.lpszA = (uint8_t *) str;
 		break;
 	}
 	case PT_UNICODE:
@@ -430,12 +430,12 @@ static bool fetch_property_value(struct fx_parser_context *parser, DATA_BLOB *bu
 		if (!pull_uint32_t(parser, &(prop->value.MVszA.cValues)) ||
 		    parser->idx + prop->value.MVszA.cValues * 4 > parser->data.length)
 			return false;
-		prop->value.MVszA.lppszA = (const char **) talloc_array(parser->mem_ctx, char *, prop->value.MVszA.cValues);
+		prop->value.MVszA.lppszA = (uint8_t **) talloc_array(parser->mem_ctx, uint8_t*, prop->value.MVszA.cValues);
 		for (i = 0; i < prop->value.MVszA.cValues; i++) {
 			str = NULL;
 			if (!pull_string8(parser, &str))
 				return false;
-			prop->value.MVszA.lppszA[i] = str;
+			prop->value.MVszA.lppszA[i] = (uint8_t *) str;
 		}
 		break;
 	}

--- a/libmapi/nspi.c
+++ b/libmapi/nspi.c
@@ -867,7 +867,7 @@ _PUBLIC_ enum MAPISTATUS nspi_GetTemplateInfo(struct nspi_context *nspi_ctx,
 	r.in.handle = &nspi_ctx->handle;
 	r.in.dwFlags = dwFlags;
 	r.in.ulType = ulType;
-	r.in.pDN = pDN;
+	r.in.pDN = (uint8_t *) pDN;
 	r.in.dwCodePage = nspi_ctx->pStat->CodePage;
 	r.in.dwLocaleID = nspi_ctx->pStat->TemplateLocale;
 	
@@ -1129,7 +1129,7 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
 	
 	paStr = talloc(mem_ctx, struct StringsArray_r);
 	paStr->Count = count;
-	paStr->Strings = usernames;
+	paStr->Strings = (uint8_t **) usernames;
 	r.in.paStr = paStr;
 
 	r.out.ppMIds = *pppMIds;

--- a/libmapi/property.c
+++ b/libmapi/property.c
@@ -623,7 +623,7 @@ _PUBLIC_ bool set_SPropValue(struct SPropValue *lpProps, const void *data)
 		lpProps->value.b = *((const uint8_t *)data);
 		break;
 	case PT_STRING8:
-		lpProps->value.lpszA = (const char *) data;
+		lpProps->value.lpszA = (uint8_t *) data;
 		break;
 	case PT_BINARY:
 	case PT_SVREID:
@@ -724,7 +724,7 @@ _PUBLIC_ void mapi_copy_spropvalues(TALLOC_CTX *mem_ctx, struct SPropValue *sour
 		prop_type = (source_value->ulPropTag & 0xFFFF);
 		switch(prop_type) {
 		case PT_STRING8:
-			dest_value->value.lpszA = talloc_strdup(mem_ctx, source_value->value.lpszA);
+			dest_value->value.lpszA = (uint8_t *) talloc_strdup(mem_ctx, (const char *) source_value->value.lpszA);
 			break;
 		case PT_UNICODE:
 			dest_value->value.lpszW = talloc_strdup(mem_ctx, source_value->value.lpszW);
@@ -747,9 +747,9 @@ _PUBLIC_ void mapi_copy_spropvalues(TALLOC_CTX *mem_ctx, struct SPropValue *sour
 		case PT_MV_STRING8:
 			dest_value->value.MVszA.cValues = source_value->value.MVszA.cValues;
 
-			dest_value->value.MVszA.lppszA = talloc_array(mem_ctx, const char *, source_value->value.MVszA.cValues);
+			dest_value->value.MVszA.lppszA = talloc_array(mem_ctx, uint8_t *, source_value->value.MVszA.cValues);
 			for (k = 0; k < source_value->value.MVszA.cValues; k++) {
-				dest_value->value.MVszA.lppszA[k] = talloc_strdup(dest_value->value.MVszA.lppszA, source_value->value.MVszA.lppszA[k]);
+				dest_value->value.MVszA.lppszA[k] = (uint8_t *) talloc_strdup(dest_value->value.MVszA.lppszA, (const char *) source_value->value.MVszA.lppszA[k]);
 			}
 			break;
 		case PT_MV_UNICODE:
@@ -818,9 +818,9 @@ _PUBLIC_ uint32_t cast_mapi_SPropValue(TALLOC_CTX *mem_ctx,
 		mapi_sprop->value.d = sprop->value.d;
 		return sizeof(uint64_t);
 	case PT_STRING8:
-		mapi_sprop->value.lpszA = sprop->value.lpszA;
+		mapi_sprop->value.lpszA = (const char *) sprop->value.lpszA;
 		if (!mapi_sprop->value.lpszA) return 0;
-		return (strlen(sprop->value.lpszA) + 1);
+		return (strlen((const char *) sprop->value.lpszA) + 1);
 	case PT_UNICODE:
 		mapi_sprop->value.lpszW = sprop->value.lpszW;
 		if (!mapi_sprop->value.lpszW) return 0;
@@ -860,7 +860,7 @@ _PUBLIC_ uint32_t cast_mapi_SPropValue(TALLOC_CTX *mem_ctx,
 		mapi_sprop->value.MVszA.strings = talloc_array(mem_ctx, struct mapi_LPSTR, 
 							       mapi_sprop->value.MVszA.cValues);
 		for (i = 0; i < mapi_sprop->value.MVszA.cValues; i++) {
-			mapi_sprop->value.MVszA.strings[i].lppszA = sprop->value.MVszA.lppszA[i];
+			mapi_sprop->value.MVszA.strings[i].lppszA = (const char *) sprop->value.MVszA.lppszA[i];
 			size += strlen(mapi_sprop->value.MVszA.strings[i].lppszA) + 1;
 		}
 		return size;
@@ -967,9 +967,9 @@ _PUBLIC_ uint32_t cast_SPropValue(TALLOC_CTX *mem_ctx,
 		sprop->value.d = mapi_sprop->value.d;
 		return sizeof(uint64_t);
 	case PT_STRING8:
-		sprop->value.lpszA = mapi_sprop->value.lpszA;
+		sprop->value.lpszA = (uint8_t *) mapi_sprop->value.lpszA;
 		if (!mapi_sprop->value.lpszA) return 0;
-		return (strlen(sprop->value.lpszA) + 1);
+		return (strlen((const char *) sprop->value.lpszA) + 1);
 	case PT_UNICODE:
 		sprop->value.lpszW = mapi_sprop->value.lpszW;
 		if (!sprop->value.lpszW) return 0;
@@ -1021,10 +1021,10 @@ _PUBLIC_ uint32_t cast_SPropValue(TALLOC_CTX *mem_ctx,
 		sprop->value.MVszA.cValues = mapi_sprop->value.MVszA.cValues;
 		size += 4;
 
-		sprop->value.MVszA.lppszA = talloc_array(mem_ctx, const char *, sprop->value.MVszA.cValues);
+		sprop->value.MVszA.lppszA = talloc_array(mem_ctx, uint8_t *, sprop->value.MVszA.cValues);
 		for (i = 0; i < sprop->value.MVszA.cValues; i++) {
-			sprop->value.MVszA.lppszA[i] = mapi_sprop->value.MVszA.strings[i].lppszA;
-			size += strlen(sprop->value.MVszA.lppszA[i]) + 1;
+			sprop->value.MVszA.lppszA[i] = (uint8_t *) mapi_sprop->value.MVszA.strings[i].lppszA;
+			size += strlen((const char *) sprop->value.MVszA.lppszA[i]) + 1;
 		}
 		return size;
 	}
@@ -2236,7 +2236,7 @@ _PUBLIC_ bool set_PropertyValue(struct PropertyValue_r *lpProp, const void *data
 		lpProp->value.l = *((const uint32_t *)data);
 		break;
 	case PT_STRING8:
-		lpProp->value.lpszA = (const char *) data;
+		lpProp->value.lpszA = (uint8_t *) data;
 		break;
 	case PT_BINARY:
 	case PT_SVREID:

--- a/libmapi/simple_mapi.c
+++ b/libmapi/simple_mapi.c
@@ -784,7 +784,7 @@ _PUBLIC_ enum MAPISTATUS ModifyUserPermission(mapi_object_t *obj_folder,
 	for (i = 0; i < rowset.cRows; i++) {
 		lpProp = get_SPropValue_SRow(&rowset.aRow[i], PR_MEMBER_NAME);
 		if (lpProp && lpProp->value.lpszA) {
-			if (!strcmp(lpProp->value.lpszA, user)) {
+			if (!strcmp((const char *) lpProp->value.lpszA, user)) {
 				rowList.ModifyCount = 1;
 				rowList.PermissionsData = talloc_array(mem_ctx, struct PermissionData, 1);
 				rowList.PermissionsData[0].PermissionDataFlags = ROW_MODIFY;
@@ -894,7 +894,7 @@ _PUBLIC_ enum MAPISTATUS RemoveUserPermission(mapi_object_t *obj_folder,
 	for (i = 0; i < rowset.cRows; i++) {
 		lpProp = get_SPropValue_SRow(&rowset.aRow[i], PR_MEMBER_NAME);
 		if (lpProp && lpProp->value.lpszA) {
-			if (!strcmp(lpProp->value.lpszA, user)) {
+			if (!strcmp((const char *) lpProp->value.lpszA, user)) {
 				rowList.ModifyCount = 1;
 				rowList.PermissionsData = talloc_array(mem_ctx, struct PermissionData, 1);
 				rowList.PermissionsData[0].PermissionDataFlags = ROW_REMOVE;

--- a/libocpf/ocpf.y
+++ b/libocpf/ocpf.y
@@ -267,7 +267,7 @@ content		:
 
 propvalue	: STRING	
 		{ 
-			ctx->lpProp.lpszA = talloc_strdup(ctx, $1); 
+			ctx->lpProp.lpszA = (uint8_t *) talloc_strdup(ctx, (char *) $1); 
 			ctx->ltype = PT_STRING8; 
 		}
 		| UNICODE
@@ -306,14 +306,14 @@ propvalue	: STRING
 
 			if (!ctx->lpProp.MVszA.cValues) {
 				ctx->lpProp.MVszA.cValues = 0;
-				ctx->lpProp.MVszA.lppszA = talloc_array(ctx, const char *, 2);
+				ctx->lpProp.MVszA.lppszA = talloc_array(ctx, uint8_t *, 2);
 			} else {
 				ctx->lpProp.MVszA.lppszA = talloc_realloc(NULL, ctx->lpProp.MVszA.lppszA, 
-									  const char *,
+									  uint8_t *,
 									  ctx->lpProp.MVszA.cValues + 2);
 			}
 			mem_ctx = (TALLOC_CTX *) ctx->lpProp.MVszA.lppszA;
-			ctx->lpProp.MVszA.lppszA[ctx->lpProp.MVszA.cValues] = talloc_strdup(mem_ctx, $3);
+			ctx->lpProp.MVszA.lppszA[ctx->lpProp.MVszA.cValues] = (uint8_t *) talloc_strdup(mem_ctx, (const char *) $3);
 			ctx->lpProp.MVszA.cValues += 1;
 
 			ctx->ltype = PT_MV_STRING8;
@@ -404,14 +404,14 @@ mvstring_content  : STRING COMMA
 
 			if (!ctx->lpProp.MVszA.cValues) {
 				ctx->lpProp.MVszA.cValues = 0;
-				ctx->lpProp.MVszA.lppszA = talloc_array(ctx, const char *, 2);
+				ctx->lpProp.MVszA.lppszA = talloc_array(ctx, uint8_t *, 2);
 			} else {
 				ctx->lpProp.MVszA.lppszA = talloc_realloc(NULL, ctx->lpProp.MVszA.lppszA, 
-									  const char *,
+									  uint8_t *,
 									  ctx->lpProp.MVszA.cValues + 2);
 			}
 			mem_ctx = (TALLOC_CTX *) ctx->lpProp.MVszA.lppszA;
-			ctx->lpProp.MVszA.lppszA[ctx->lpProp.MVszA.cValues] = talloc_strdup(mem_ctx, $1);
+			ctx->lpProp.MVszA.lppszA[ctx->lpProp.MVszA.cValues] = (uint8_t *) talloc_strdup(mem_ctx, (const char *) $1);
 			ctx->lpProp.MVszA.cValues += 1;
 		  }
 		  ;

--- a/libocpf/ocpf_api.c
+++ b/libocpf/ocpf_api.c
@@ -162,9 +162,9 @@ int ocpf_set_propvalue(TALLOC_CTX *mem_ctx,
 	switch (proptype) {
 	case PT_STRING8:
 		if (unescape) {
-			str = ocpf_write_unescape_string(ctx, lpProp.lpszA);
+			str = ocpf_write_unescape_string(ctx, (const char *) lpProp.lpszA);
 		} else {
-			str = talloc_strdup(ctx, lpProp.lpszA);
+			str = talloc_strdup(ctx, (const char *) lpProp.lpszA);
 		}
 		*value = talloc_memdup(ctx, str, strlen(str) + 1);
 		talloc_free(str);
@@ -220,17 +220,17 @@ int ocpf_set_propvalue(TALLOC_CTX *mem_ctx,
 	case PT_MV_STRING8:
 		*value = (const void *)talloc_zero(ctx, struct StringArray_r);
 		((struct StringArray_r *)*value)->cValues = lpProp.MVszA.cValues;
-		((struct StringArray_r *)*value)->lppszA = talloc_array(ctx, const char *, lpProp.MVszA.cValues);
+		((struct StringArray_r *)*value)->lppszA = talloc_array(ctx, uint8_t *, lpProp.MVszA.cValues);
 		{
 			uint32_t	i;
 
 			for (i = 0; i < lpProp.MVszA.cValues; i++) {
 				if (unescape) {
-					str = ocpf_write_unescape_string(ctx, lpProp.MVszA.lppszA[i]);
+					str = ocpf_write_unescape_string(ctx, (const char *) lpProp.MVszA.lppszA[i]);
 				} else {
 					str = (char *)lpProp.MVszA.lppszA[i];
 				}
-				((struct StringArray_r *)*value)->lppszA[i] = talloc_strdup(ctx, str);
+				((struct StringArray_r *)*value)->lppszA[i] = (uint8_t *) talloc_strdup(ctx, str);
 				talloc_free(str);
 			}
 		}

--- a/mapiproxy/dcesrv_mapiproxy_nspi.c
+++ b/mapiproxy/dcesrv_mapiproxy_nspi.c
@@ -101,10 +101,10 @@ bool mapiproxy_NspiGetProps(struct dcesrv_call_state *dce_call, struct NspiGetPr
 
 	/* Step 3. Modify Exchange binding strings and only return ncacn_ip_tcp */
 	slpstr->cValues = 1;
-	slpstr->lppszA[0] = talloc_asprintf(dce_call, "ncacn_ip_tcp:%s.%s", 
+	slpstr->lppszA[0] = (uint8_t *) talloc_asprintf(dce_call, "ncacn_ip_tcp:%s.%s", 
 					    lpcfg_netbios_name(dce_call->conn->dce_ctx->lp_ctx), 
 					    lpcfg_realm(dce_call->conn->dce_ctx->lp_ctx));
-	slpstr->lppszA[0] = strlower_talloc(dce_call, slpstr->lppszA[0]);
+	slpstr->lppszA[0] = (uint8_t *) strlower_talloc(dce_call, (const char *) slpstr->lppszA[0]);
 
 	return true;
 }
@@ -158,15 +158,15 @@ bool mapiproxy_NspiQueryRows(struct dcesrv_call_state *dce_call, struct NspiQuer
 	if (lpProp->ulPropTag != PR_EMS_AB_HOME_MDB) return false;
 
 	if (private->exchname) {
-		if (strstr(lpProp->value.lpszA, private->exchname)) {
-			lpProp->value.lpszA = string_sub_talloc((TALLOC_CTX *) dce_call, lpProp->value.lpszA, private->exchname, 
+		if (strstr((const char *) lpProp->value.lpszA, private->exchname)) {
+			lpProp->value.lpszA = (uint8_t *) string_sub_talloc((TALLOC_CTX *) dce_call, (const char *) lpProp->value.lpszA, private->exchname, 
 								lpcfg_netbios_name(dce_call->conn->dce_ctx->lp_ctx));	
 		}
 	} else {
-		lpszA = talloc_strdup(dce_call, lpProp->value.lpszA);
+		lpszA = talloc_strdup(dce_call, (const char *) lpProp->value.lpszA);
 		if ((exchname = x500_get_servername(lpszA))) {
 			private->exchname = talloc_strdup(NULL, exchname);
-			lpProp->value.lpszA = string_sub_talloc((TALLOC_CTX *) dce_call, lpProp->value.lpszA, exchname, 
+			lpProp->value.lpszA = (uint8_t *) string_sub_talloc((TALLOC_CTX *) dce_call, (const char *) lpProp->value.lpszA, exchname, 
 								lpcfg_netbios_name(dce_call->conn->dce_ctx->lp_ctx));
 			talloc_free(exchname);
 		}
@@ -200,8 +200,8 @@ bool mapiproxy_NspiDNToMId(struct dcesrv_call_state *dce_call, struct NspiDNToMI
 	if (!private->exchname) return false;
 
 	for (i = 0; i < r->in.pNames->Count; i++) {
-		if (strstr(r->in.pNames->Strings[i], proxyname)) {
-			r->in.pNames->Strings[i] = string_sub_talloc((TALLOC_CTX *) dce_call, r->in.pNames->Strings[i], proxyname, private->exchname);
+		if (strstr((const char *) r->in.pNames->Strings[i], proxyname)) {
+			r->in.pNames->Strings[i] = (uint8_t *) string_sub_talloc((TALLOC_CTX *) dce_call, (const char *) r->in.pNames->Strings[i], proxyname, private->exchname);
 			return true;
 		}
 	}

--- a/mapiproxy/dcesrv_mapiproxy_rfr.c
+++ b/mapiproxy/dcesrv_mapiproxy_rfr.c
@@ -40,10 +40,10 @@ bool mapiproxy_RfrGetNewDSA(struct dcesrv_call_state *dce_call, struct RfrGetNew
 	/* Sanity checks */
 	if (!r->out.ppszServer) return false;
 
-	*r->out.ppszServer = talloc_asprintf(dce_call, "%s.%s", 
+	*r->out.ppszServer = (uint8_t *) talloc_asprintf(dce_call, "%s.%s", 
 					     lpcfg_netbios_name(dce_call->conn->dce_ctx->lp_ctx), 
 					     lpcfg_realm(dce_call->conn->dce_ctx->lp_ctx));
-	*r->out.ppszServer = strlower_talloc(dce_call, *r->out.ppszServer);
+	*r->out.ppszServer = (uint8_t *) strlower_talloc(dce_call, (const char *) *r->out.ppszServer);
 
 	return true;
 }

--- a/mapiproxy/libmapiproxy/openchangedb.c
+++ b/mapiproxy/libmapiproxy/openchangedb.c
@@ -525,7 +525,7 @@ _PUBLIC_ char *openchangedb_set_folder_property_data(TALLOC_CTX *mem_ctx,
 		data = talloc_asprintf(mem_ctx, "%"PRIu64, value->value.d);
 		break;
 	case PT_STRING8:
-		data = talloc_strdup(mem_ctx, value->value.lpszA);
+		data = talloc_strdup(mem_ctx, (const char *) value->value.lpszA);
 		break;
 	case PT_UNICODE:
 		data = talloc_strdup(mem_ctx, value->value.lpszW);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -124,17 +124,17 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Step 3. Check if input user DN belongs to the Exchange organization */
-	if (emsmdbp_verify_userdn(dce_call, emsmdbp_ctx, r->in.szUserDN, &msg) == false) {
+	if (emsmdbp_verify_userdn(dce_call, emsmdbp_ctx, (const char *) r->in.szUserDN, &msg) == false) {
 		talloc_free(emsmdbp_ctx);
 		goto failure;
 	}
 
-	emsmdbp_ctx->szUserDN = talloc_strdup(emsmdbp_ctx, r->in.szUserDN);
+	emsmdbp_ctx->szUserDN = talloc_strdup(emsmdbp_ctx, (const char *) r->in.szUserDN);
 	emsmdbp_ctx->userLanguage = r->in.ulLcidString;
 
 	/* Step 4. Retrieve the display name of the user */
-	*r->out.szDisplayName = ldb_msg_find_attr_as_string(msg, "displayName", NULL);
-	emsmdbp_ctx->szDisplayName = talloc_strdup(emsmdbp_ctx, *r->out.szDisplayName);
+	*r->out.szDisplayName = (uint8_t *) ldb_msg_find_attr_as_string(msg, "displayName", NULL);
+	emsmdbp_ctx->szDisplayName = talloc_strdup(emsmdbp_ctx, (const char *) *r->out.szDisplayName);
 
 	/* Step 5. Retrieve the dinstinguished name of the server */
 	mailNickname = ldb_msg_find_attr_as_string(msg, "mailNickname", NULL);
@@ -146,7 +146,7 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 	}
 
 	*dnprefix = '\0';
-	*r->out.szDNPrefix = strupper_talloc(mem_ctx, userDN);
+	*r->out.szDNPrefix = (uint8_t *) strupper_talloc(mem_ctx, userDN);
 
 	/* Step 6. Fill EcDoConnect reply */
 	handle = dcesrv_handle_new(dce_call->context, EXCHANGE_HANDLE_EMSMDB);
@@ -1188,11 +1188,11 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 		*r->out.pcmsRetryDelay = 0;
 		*r->out.picxr = 0;
 
-		r->out.szDNPrefix = (const char **)talloc_array(mem_ctx, char *, 2);
-		r->out.szDNPrefix[0] = talloc_strdup(mem_ctx, tmp);
+		r->out.szDNPrefix = (uint8_t **)talloc_array(mem_ctx, uint8_t *, 2);
+		r->out.szDNPrefix[0] = (uint8_t *) talloc_strdup(mem_ctx, tmp);
 
-		r->out.szDisplayName = (const char **)talloc_array(mem_ctx, char *, 2);
-		r->out.szDisplayName[0] = talloc_strdup(mem_ctx, tmp);
+		r->out.szDisplayName = (uint8_t **)talloc_array(mem_ctx, uint8_t *, 2);
+		r->out.szDisplayName[0] = (uint8_t *) talloc_strdup(mem_ctx, tmp);
 
 		r->out.rgwServerVersion[0] = 0;
 		r->out.rgwServerVersion[1] = 0;
@@ -1212,7 +1212,7 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 		goto failure;
 	}
 
-	if (!r->in.szUserDN || strlen(r->in.szUserDN) == 0) {
+	if (!r->in.szUserDN || strlen((const char *) r->in.szUserDN) == 0) {
 	  OC_DEBUG(5, "r->in.szUserDN is NULL or empty\n");
 		r->out.result = MAPI_E_NO_ACCESS;
 		goto failure;
@@ -1236,18 +1236,18 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Step 3. Check if input user DN belongs to the Exchange organization */
-	if (emsmdbp_verify_userdn(dce_call, emsmdbp_ctx, r->in.szUserDN, &msg) == false) {
+	if (emsmdbp_verify_userdn(dce_call, emsmdbp_ctx, (const char *) r->in.szUserDN, &msg) == false) {
 		talloc_free(emsmdbp_ctx);
 		r->out.result = ecUnknownUser;
 		goto failure;
 	}
 
-	emsmdbp_ctx->szUserDN = talloc_strdup(emsmdbp_ctx, r->in.szUserDN);
+	emsmdbp_ctx->szUserDN = talloc_strdup(emsmdbp_ctx, (const char *) r->in.szUserDN);
 	emsmdbp_ctx->userLanguage = r->in.ulLcidString;
 
 	/* Step 4. Retrieve the display name of the user */
-	*r->out.szDisplayName = ldb_msg_find_attr_as_string(msg, "displayName", NULL);
-	emsmdbp_ctx->szDisplayName = talloc_strdup(emsmdbp_ctx, *r->out.szDisplayName);
+	*r->out.szDisplayName = (uint8_t *) ldb_msg_find_attr_as_string(msg, "displayName", NULL);
+	emsmdbp_ctx->szDisplayName = talloc_strdup(emsmdbp_ctx, (const char *) *r->out.szDisplayName);
 
 	/* Step 5. Retrieve the distinguished name of the server */
 	mailNickname = ldb_msg_find_attr_as_string(msg, "mailNickname", NULL);
@@ -1262,7 +1262,7 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 	*dnprefix = '\0';
 	emsmdbp_ctx->szDNPrefix = talloc_strdup(emsmdbp_ctx, userDN);
 	OPENCHANGE_RETVAL_IF(emsmdbp_ctx->szDNPrefix == NULL, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
-	*r->out.szDNPrefix = strupper_talloc(mem_ctx, userDN);
+	*r->out.szDNPrefix = (uint8_t *) strupper_talloc(mem_ctx, userDN);
 	OPENCHANGE_RETVAL_IF(*r->out.szDNPrefix == NULL, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
 	/* Step 6. Fill EcDoConnectEx reply */

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -910,7 +910,7 @@ static void dcesrv_NspiDNToMId(struct dcesrv_call_state *dce_call,
 
 	for (i = 0; i < r->in.pNames->Count; i++) {
 		/* Step 1. Check if the input legacyDN exists */
-		retval = emsabp_search_legacyExchangeDN(emsabp_ctx, r->in.pNames->Strings[i], &msg, &pbUseConfPartition);
+		retval = emsabp_search_legacyExchangeDN(emsabp_ctx, (const char *) r->in.pNames->Strings[i], &msg, &pbUseConfPartition);
 		if (retval != MAPI_E_SUCCESS) {
 			r->out.ppMIds[0]->aulPropTag[i] = (enum MAPITAGS) 0;
 		} else {
@@ -1456,7 +1456,7 @@ static void dcesrv_NspiResolveNames(struct dcesrv_call_state *dce_call,
 	reqw.in.pPropTags = r->in.pPropTags;
 	reqw.in.paWStr = &reqw_strings_array;
 	reqw.in.paWStr->Count = r->in.paStr->Count;
-	reqw.in.paWStr->Strings = r->in.paStr->Strings;
+	reqw.in.paWStr->Strings = (const char **) r->in.paStr->Strings;
 
 	reqw.out.ppMIds = r->out.ppMIds;
 	reqw.out.ppRows = r->out.ppRows ;

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -619,9 +619,9 @@ _PUBLIC_ void *emsabp_query(TALLOC_CTX *mem_ctx, struct emsabp_context *emsabp_c
 
 		mvszA = talloc(mem_ctx, struct StringArray_r);
 		mvszA->cValues = ldb_element[0].num_values & 0xFFFFFFFF;
-		mvszA->lppszA = talloc_array(mem_ctx, const char *, mvszA->cValues);
+		mvszA->lppszA = talloc_array(mem_ctx, uint8_t *, mvszA->cValues);
 		for (i = 0; i < mvszA->cValues; i++) {
-			mvszA->lppszA[i] = talloc_strdup(mem_ctx, (char *)ldb_element->values[i].data);
+			mvszA->lppszA[i] = (uint8_t *) talloc_strdup(mem_ctx, (const char *)ldb_element->values[i].data);
 		}
 		data = (void *) mvszA;
 		break;
@@ -911,7 +911,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_table_fetch_attrs(TALLOC_CTX *mem_ctx, struct em
 				lpProps.value.l = containerID;
 				break;
 			case PidTagDisplayName_string8:
-				lpProps.value.lpszA = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(msg, "displayName", NULL));
+				lpProps.value.lpszA = (uint8_t *)talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(msg, "displayName", NULL));
 				if (!lpProps.value.lpszA) {
 					proptag = (int) lpProps.ulPropTag;
 					proptag &= 0xFFFF0000;

--- a/mapiproxy/servers/default/rfr/dcesrv_exchange_ds_rfr.c
+++ b/mapiproxy/servers/default/rfr/dcesrv_exchange_ds_rfr.c
@@ -73,8 +73,8 @@ static enum MAPISTATUS dcesrv_RfrGetNewDSA(struct dcesrv_call_state *dce_call,
 
 	fqdn = talloc_asprintf(mem_ctx, "%s.%s", netbiosname, realm);
 	r->out.ppszUnused = NULL;
-	r->out.ppszServer = talloc_array(mem_ctx, const char *, 2);
-	r->out.ppszServer[0] = strlower_talloc(mem_ctx, fqdn);
+	r->out.ppszServer = talloc_array(mem_ctx, uint8_t *, 2);
+	r->out.ppszServer[0] = (uint8_t *) strlower_talloc(mem_ctx, fqdn);
 	r->out.ppszServer[1] = NULL;
 	r->out.result = MAPI_E_SUCCESS;
 
@@ -105,7 +105,7 @@ static enum MAPISTATUS dcesrv_RfrGetFQDNFromLegacyDN(struct dcesrv_call_state *d
 		OC_DEBUG(1, "No challenge requested by client, cannot authenticate");
 
 	failure:
-		r->out.ppszServerFQDN = talloc_array(mem_ctx, const char *, 2);
+		r->out.ppszServerFQDN = talloc_array(mem_ctx, uint8_t *, 2);
 		r->out.ppszServerFQDN[0] = NULL;
 		r->out.result = MAPI_E_LOGON_FAILED;
 		return MAPI_E_LOGON_FAILED;
@@ -118,8 +118,8 @@ static enum MAPISTATUS dcesrv_RfrGetFQDNFromLegacyDN(struct dcesrv_call_state *d
 	}
 
 	fqdn = talloc_asprintf(mem_ctx, "%s.%s", netbiosname, realm);
-	r->out.ppszServerFQDN = talloc_array(mem_ctx, const char *, 2);
-	r->out.ppszServerFQDN[0] = strlower_talloc(mem_ctx, fqdn);
+	r->out.ppszServerFQDN = talloc_array(mem_ctx, uint8_t *, 2);
+	r->out.ppszServerFQDN[0] = (uint8_t *) strlower_talloc(mem_ctx, fqdn);
 	talloc_free(fqdn);
 	r->out.result = MAPI_E_SUCCESS;
 

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -1076,10 +1076,10 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 	uint32_t	cntr_rgwBestVersion_0;
 
 	if (flags & NDR_IN) {
-		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_DOS)));
+		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_UNIX)));
 		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
-		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_DOS)));
-		NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, r->in.szUserDN, ndr_charset_length(r->in.szUserDN, CH_DOS), sizeof (uint8_t), CH_DOS));
+		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_UNIX)));
+		NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, r->in.szUserDN, ndr_charset_length(r->in.szUserDN, CH_UNIX), sizeof (uint8_t), CH_UNIX));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.ulFlags));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.ulConMod));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.cbLimit));
@@ -1148,20 +1148,20 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 		}
 		NDR_CHECK(ndr_push_unique_ptr(ndr, *r->out.szDNPrefix));
 		if (r->out.szDNPrefix) {
-			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_DOS)));
+			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX)));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
-			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_DOS)));
-			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDNPrefix, ndr_charset_length(*r->out.szDNPrefix, CH_DOS), sizeof(uint8_t), CH_DOS));
+			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX)));
+			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDNPrefix, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX), sizeof(uint8_t), CH_UNIX));
 		}
 		if (r->out.szDisplayName == NULL) {
 			return ndr_push_error(ndr, NDR_ERR_INVALID_POINTER, "NULL [ref] pointer: szDisplayName");
 		}
 		NDR_CHECK(ndr_push_unique_ptr(ndr, *r->out.szDisplayName));
 		if (*r->out.szDisplayName) {
-			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_DOS)));
+			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_UNIX)));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
-			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_DOS)));
-			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDisplayName, ndr_charset_length(*r->out.szDisplayName, CH_DOS), sizeof(uint8_t), CH_DOS));
+			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_UNIX)));
+			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDisplayName, ndr_charset_length(*r->out.szDisplayName, CH_UNIX), sizeof(uint8_t), CH_UNIX));
 		}
 		for (cntr_rgwServerVersion_0 = 0; cntr_rgwServerVersion_0 < 3; cntr_rgwServerVersion_0++) {
 			NDR_CHECK(ndr_push_uint16(ndr, NDR_SCALARS, r->out.rgwServerVersion[cntr_rgwServerVersion_0]));
@@ -1244,7 +1244,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 			return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, &r->in.szUserDN), ndr_get_array_length(ndr, &r->in.szUserDN));
 		}
 		NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, &r->in.szUserDN), sizeof(uint8_t)));
-		NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, &r->in.szUserDN, ndr_get_array_length(ndr, &r->in.szUserDN), sizeof(uint8_t), CH_DOS));
+		NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, &r->in.szUserDN, ndr_get_array_length(ndr, &r->in.szUserDN), sizeof(uint8_t), CH_UNIX));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.ulFlags));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.ulConMod));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.cbLimit));
@@ -1368,7 +1368,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 				return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, r->out.szDNPrefix), ndr_get_array_length(ndr, r->out.szDNPrefix));
 			}
 			NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, r->out.szDNPrefix), sizeof(uint8_t)));
-			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDNPrefix, ndr_get_array_length(ndr, r->out.szDNPrefix), sizeof(uint8_t), CH_DOS));
+			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDNPrefix, ndr_get_array_length(ndr, r->out.szDNPrefix), sizeof(uint8_t), CH_UNIX));
 			NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDNPrefix_1, 0);
 		}
 		NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDNPrefix_0, LIBNDR_FLAG_REF_ALLOC);
@@ -1393,7 +1393,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 				return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, r->out.szDisplayName), ndr_get_array_length(ndr, r->out.szDisplayName));
 			}
 			NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, r->out.szDisplayName), sizeof(uint8_t)));
-			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDisplayName, ndr_get_array_length(ndr, r->out.szDisplayName), sizeof(uint8_t), CH_DOS));
+			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDisplayName, ndr_get_array_length(ndr, r->out.szDisplayName), sizeof(uint8_t), CH_UNIX));
 			NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDisplayName_1, 0);
 		}
 		NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDisplayName_0, LIBNDR_FLAG_REF_ALLOC);

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -1079,7 +1079,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_UNIX)));
 		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
 		NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(r->in.szUserDN, CH_UNIX)));
-		NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, r->in.szUserDN, ndr_charset_length(r->in.szUserDN, CH_UNIX), sizeof (uint8_t), CH_UNIX));
+		NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, (const char *) r->in.szUserDN, ndr_charset_length(r->in.szUserDN, CH_UNIX), sizeof (uint8_t), CH_UNIX));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.ulFlags));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.ulConMod));
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, r->in.cbLimit));
@@ -1151,7 +1151,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX)));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX)));
-			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDNPrefix, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX), sizeof(uint8_t), CH_UNIX));
+			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, (const char *) *r->out.szDNPrefix, ndr_charset_length(*r->out.szDNPrefix, CH_UNIX), sizeof(uint8_t), CH_UNIX));
 		}
 		if (r->out.szDisplayName == NULL) {
 			return ndr_push_error(ndr, NDR_ERR_INVALID_POINTER, "NULL [ref] pointer: szDisplayName");
@@ -1161,7 +1161,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_UNIX)));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, 0));
 			NDR_CHECK(ndr_push_uint3264(ndr, NDR_SCALARS, ndr_charset_length(*r->out.szDisplayName, CH_UNIX)));
-			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, *r->out.szDisplayName, ndr_charset_length(*r->out.szDisplayName, CH_UNIX), sizeof(uint8_t), CH_UNIX));
+			NDR_CHECK(ndr_push_charset(ndr, NDR_SCALARS, (const char *) *r->out.szDisplayName, ndr_charset_length((const char *) *r->out.szDisplayName, CH_UNIX), sizeof(uint8_t), CH_UNIX));
 		}
 		for (cntr_rgwServerVersion_0 = 0; cntr_rgwServerVersion_0 < 3; cntr_rgwServerVersion_0++) {
 			NDR_CHECK(ndr_push_uint16(ndr, NDR_SCALARS, r->out.rgwServerVersion[cntr_rgwServerVersion_0]));
@@ -1244,7 +1244,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 			return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, &r->in.szUserDN), ndr_get_array_length(ndr, &r->in.szUserDN));
 		}
 		NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, &r->in.szUserDN), sizeof(uint8_t)));
-		NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, &r->in.szUserDN, ndr_get_array_length(ndr, &r->in.szUserDN), sizeof(uint8_t), CH_UNIX));
+		NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, (const char **) &r->in.szUserDN, ndr_get_array_length(ndr, (const char *) &r->in.szUserDN), sizeof(uint8_t), CH_UNIX));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.ulFlags));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.ulConMod));
 		NDR_CHECK(ndr_pull_uint32(ndr, NDR_SCALARS, &r->in.cbLimit));
@@ -1367,8 +1367,8 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 			if (ndr_get_array_length(ndr, r->out.szDNPrefix) > ndr_get_array_size(ndr, r->out.szDNPrefix)) {
 				return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, r->out.szDNPrefix), ndr_get_array_length(ndr, r->out.szDNPrefix));
 			}
-			NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, r->out.szDNPrefix), sizeof(uint8_t)));
-			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDNPrefix, ndr_get_array_length(ndr, r->out.szDNPrefix), sizeof(uint8_t), CH_UNIX));
+			NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, (const char *) r->out.szDNPrefix), sizeof(uint8_t)));
+			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, (const char **) r->out.szDNPrefix, ndr_get_array_length(ndr, (const char *) r->out.szDNPrefix), sizeof(uint8_t), CH_UNIX));
 			NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDNPrefix_1, 0);
 		}
 		NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDNPrefix_0, LIBNDR_FLAG_REF_ALLOC);
@@ -1393,7 +1393,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 				return ndr_pull_error(ndr, NDR_ERR_ARRAY_SIZE, "Bad array size %u should exceed array length %u", ndr_get_array_size(ndr, r->out.szDisplayName), ndr_get_array_length(ndr, r->out.szDisplayName));
 			}
 			NDR_CHECK(ndr_check_string_terminator(ndr, ndr_get_array_length(ndr, r->out.szDisplayName), sizeof(uint8_t)));
-			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, r->out.szDisplayName, ndr_get_array_length(ndr, r->out.szDisplayName), sizeof(uint8_t), CH_UNIX));
+			NDR_CHECK(ndr_pull_charset(ndr, NDR_SCALARS, (const char **)r->out.szDisplayName, ndr_get_array_length(ndr, (const char *) r->out.szDisplayName), sizeof(uint8_t), CH_UNIX));
 			NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDisplayName_1, 0);
 		}
 		NDR_PULL_SET_MEM_CTX(ndr, _mem_save_szDisplayName_0, LIBNDR_FLAG_REF_ALLOC);
@@ -1455,7 +1455,7 @@ _PUBLIC_ void ndr_print_EcDoConnectEx(struct ndr_print *ndr, const char *name, i
 	if (flags & NDR_IN) {
 		ndr_print_struct(ndr, "in", "EcDoConnectEx");
 		ndr->depth++;
-		ndr_print_string(ndr, "szUserDN", r->in.szUserDN);
+		ndr_print_string(ndr, "szUserDN", (const char *) r->in.szUserDN);
 		ndr_print_uint32(ndr, "ulFlags", r->in.ulFlags);
 		ndr_print_uint32(ndr, "ulConMod", r->in.ulConMod);
 		ndr_print_uint32(ndr, "cbLimit", r->in.cbLimit);
@@ -1519,7 +1519,7 @@ _PUBLIC_ void ndr_print_EcDoConnectEx(struct ndr_print *ndr, const char *name, i
 		if (r->out.szDNPrefix && *r->out.szDNPrefix) {
 			ndr_print_ptr(ndr, "szDNPrefix", *r->out.szDNPrefix);
 			ndr->depth++;
-			ndr_print_string(ndr, "szDNPrefix", *r->out.szDNPrefix);
+			ndr_print_string(ndr, "szDNPrefix", (const char *) *r->out.szDNPrefix);
 			ndr->depth--;
 		}
 		ndr->depth--;
@@ -1528,7 +1528,7 @@ _PUBLIC_ void ndr_print_EcDoConnectEx(struct ndr_print *ndr, const char *name, i
 		if (r->out.szDisplayName && *r->out.szDisplayName) {
 			ndr_print_ptr(ndr, "szDisplayName", *r->out.szDisplayName);
 			ndr->depth++;
-			ndr_print_string(ndr, "szDisplayName", *r->out.szDisplayName);
+			ndr_print_string(ndr, "szDisplayName", (const char *) *r->out.szDisplayName);
 			ndr->depth--;
 		}
 		ndr->depth--;

--- a/testsuite/libmapi/mapi_property.c
+++ b/testsuite/libmapi/mapi_property.c
@@ -58,9 +58,9 @@ static int SPropValue_cmp(const struct SPropValue *left, const struct SPropValue
 	case PT_I8:
 		return left->value.d - right->value.d;
 	case PT_STRING8:
-		return strcmp(left->value.lpszA, right->value.lpszA);
+		return strcmp((const char *) left->value.lpszA, (const char *) right->value.lpszA);
 	case PT_UNICODE:
-		return strcmp(left->value.lpszW, right->value.lpszW);
+		return strcmp((const char *) left->value.lpszW, (const char *) right->value.lpszW);
 	case PT_SVREID:
 	case PT_BINARY:
 	{
@@ -88,7 +88,7 @@ static int SPropValue_cmp(const struct SPropValue *left, const struct SPropValue
 			return res;
 		}
 		for (i = 0; i < left->value.MVszA.cValues; i++) {
-			res = strcmp(left->value.MVszA.lppszA[i], right->value.MVszA.lppszA[i]);
+			res = strcmp((const char *) left->value.MVszA.lppszA[i], (const char *) right->value.MVszA.lppszA[i]);
 			if (res != 0) {
 				return res;
 			}
@@ -331,9 +331,9 @@ static void _make_test_srow(TALLOC_CTX *mem_ctx)
 	/* PT_MV_STRING8 */
 	prop_val.ulPropTag = PR_EMS_AB_PROXY_ADDRESSES;
 	prop_val.value.MVszA.cValues = 2;
-	prop_val.value.MVszA.lppszA = talloc_array(test_srow, const char *, prop_val.value.MVszA.cValues);
-	prop_val.value.MVszA.lppszA[0] = "string 1";
-	prop_val.value.MVszA.lppszA[1] = "string 2";
+	prop_val.value.MVszA.lppszA = talloc_array(test_srow, uint8_t *, prop_val.value.MVszA.cValues);
+	prop_val.value.MVszA.lppszA[0] = (uint8_t *) "string 1";
+	prop_val.value.MVszA.lppszA[1] = (uint8_t *) "string 2";
 	SRow_addprop(test_srow, prop_val);
 	/* PT_MV_UNICODE - same layout as PT_MV_STRING8 */
 	prop_val.ulPropTag = PR_EMS_AB_PROXY_ADDRESSES_UNICODE;

--- a/utils/mapiprofile.c
+++ b/utils/mapiprofile.c
@@ -387,7 +387,7 @@ static void mapiprofile_list(struct mapi_context *mapi_ctx, const char *profdb)
 		const char	*name = NULL;
 		uint32_t	dflt = 0;
 
-		name = proftable.aRow[count].lpProps[0].value.lpszA;
+		name = (const char *) proftable.aRow[count].lpProps[0].value.lpszA;
 		dflt = proftable.aRow[count].lpProps[1].value.l;
 
 		if (dflt) {

--- a/utils/mapitest/modules/module_mapidump.c
+++ b/utils/mapitest/modules/module_mapidump.c
@@ -73,7 +73,7 @@ _PUBLIC_ bool mapitest_mapidump_spropvalue(struct mapitest *mt)
 
 	propvalue.ulPropTag = PR_SENDER_NAME; /* enum MAPITAGS */
 	propvalue.dwAlignPad = 0;
-	propvalue.value.lpszA = "Mr. The Sender"; /* union SPropValue_CTR */
+	propvalue.value.lpszA = (uint8_t *) "Mr. The Sender"; /* union SPropValue_CTR */
 	mapidump_SPropValue(propvalue, "[sep]");
 
 	propvalue.ulPropTag = PR_REPORT_TAG; /* enum MAPITAGS */
@@ -101,10 +101,10 @@ _PUBLIC_ bool mapitest_mapidump_spropvalue(struct mapitest *mt)
 	propvalue.ulPropTag = PidTagScheduleInfoDelegateNames;
 	propvalue.dwAlignPad = 0;
 	mvstr.cValues = 3;
-	mvstr.lppszA = talloc_array(mt->mem_ctx, const char *, mvstr.cValues);
-	mvstr.lppszA[0] = talloc_strdup(mt->mem_ctx, "Foo");
-	mvstr.lppszA[1] = talloc_strdup(mt->mem_ctx, "A longer string");
-	mvstr.lppszA[2] = talloc_strdup(mt->mem_ctx, "All strung out on bugs");
+	mvstr.lppszA = talloc_array(mt->mem_ctx, uint8_t *, mvstr.cValues);
+	mvstr.lppszA[0] = (uint8_t *) talloc_strdup(mt->mem_ctx, "Foo");
+	mvstr.lppszA[1] = (uint8_t *) talloc_strdup(mt->mem_ctx, "A longer string");
+	mvstr.lppszA[2] = (uint8_t *) talloc_strdup(mt->mem_ctx, "All strung out on bugs");
 
 	propvalue.value.MVszA = mvstr;
 	mapidump_SPropValue(propvalue, "[sep]");
@@ -192,17 +192,17 @@ _PUBLIC_ bool mapitest_mapidump_srowset(struct mapitest *mt)
 	SRow_addprop(&(srowset.aRow[0]), SPropValue);
 
 	SPropValue.ulPropTag = PR_GIVEN_NAME;
-	SPropValue.value.lpszA = "gname";
+	SPropValue.value.lpszA = (uint8_t *) "gname";
 	SRow_addprop(&(srowset.aRow[0]), SPropValue);
 
 	srowset.aRow[1].cValues = 0;
 	srowset.aRow[1].lpProps = talloc_zero(mt->mem_ctx, struct SPropValue);
 	SPropValue.ulPropTag = PR_GIVEN_NAME;
-	SPropValue.value.lpszA = "kname";
+	SPropValue.value.lpszA = (uint8_t *) "kname";
 	SRow_addprop(&(srowset.aRow[1]), SPropValue);
 
 	SPropValue.ulPropTag = PR_7BIT_DISPLAY_NAME;
-	SPropValue.value.lpszA = "lname";
+	SPropValue.value.lpszA = (uint8_t *) "lname";
 	SRow_addprop(&(srowset.aRow[1]), SPropValue);
 
 	mapidump_SRowSet(&srowset, "[sep]");
@@ -231,19 +231,19 @@ _PUBLIC_ bool mapitest_mapidump_pabentry(struct mapitest *mt)
 	pabentry.lpProps = talloc_zero(mt->mem_ctx, struct PropertyValue_r);
 
 	value.ulPropTag = PR_ADDRTYPE_UNICODE;
-	value.value.lpszA = "dummy addrtype";
+	value.value.lpszA = (uint8_t *) "dummy addrtype";
 	PropertyRow_addprop(&(pabentry), value);
 
 	value.ulPropTag = PR_DISPLAY_NAME_UNICODE;
-	value.value.lpszA = "dummy display name";
+	value.value.lpszA = (uint8_t *) "dummy display name";
 	PropertyRow_addprop(&(pabentry), value);
 
 	value.ulPropTag = PR_EMAIL_ADDRESS_UNICODE;
-	value.value.lpszA = "dummy@example.com";
+	value.value.lpszA = (uint8_t *) "dummy@example.com";
 	PropertyRow_addprop(&(pabentry), value);
 
 	value.ulPropTag = PR_ACCOUNT_UNICODE;
-	value.value.lpszA = "dummy account";
+	value.value.lpszA = (uint8_t *) "dummy account";
 	PropertyRow_addprop(&(pabentry), value);
 
 	mapidump_PAB_entry(&pabentry);
@@ -272,10 +272,10 @@ _PUBLIC_ bool mapitest_mapidump_note(struct mapitest *mt)
 	props.lpProps = talloc_array(mt->mem_ctx, struct mapi_SPropValue, props.cValues);
 
 	props.lpProps[0].ulPropTag = PR_CONVERSATION_TOPIC;
-	props.lpProps[0].value.lpszA = "Topic of the Note";
+	props.lpProps[0].value.lpszA = (char *) "Topic of the Note";
 
 	props.lpProps[1].ulPropTag = PR_BODY;
-	props.lpProps[1].value.lpszA = "This is the body of the note. It has two sentences.";
+	props.lpProps[1].value.lpszA = (char *) "This is the body of the note. It has two sentences.";
 
 	props.lpProps[2].ulPropTag = PR_CLIENT_SUBMIT_TIME;
 	props.lpProps[2].value.ft.dwLowDateTime = 0x12345678;
@@ -284,7 +284,7 @@ _PUBLIC_ bool mapitest_mapidump_note(struct mapitest *mt)
 	mapidump_note(&props, "[dummy ID]");
 
 	props.lpProps[1].ulPropTag = PR_BODY_HTML;
-	props.lpProps[1].value.lpszA = "<h1>Heading for the Note</h1>\n<p>This is the body of the note. It has two sentences.</p>";
+	props.lpProps[1].value.lpszA = (char *) "<h1>Heading for the Note</h1>\n<p>This is the body of the note. It has two sentences.</p>";
 
 	mapidump_note(&props, "[dummy ID]");
 
@@ -315,10 +315,10 @@ _PUBLIC_ bool mapitest_mapidump_task(struct mapitest *mt)
 	props.lpProps = talloc_array(mt->mem_ctx, struct mapi_SPropValue, props.cValues);
 
 	props.lpProps[0].ulPropTag = PR_CONVERSATION_TOPIC;
-	props.lpProps[0].value.lpszA = "Topic of the Task";
+	props.lpProps[0].value.lpszA = (char *) "Topic of the Task";
 
 	props.lpProps[1].ulPropTag = PR_BODY;
-	props.lpProps[1].value.lpszA = "This is the body of the task. It has two sentences.";
+	props.lpProps[1].value.lpszA = (char *) "This is the body of the task. It has two sentences.";
 
 	props.lpProps[2].ulPropTag = PidLidTaskDueDate;
 	props.lpProps[2].value.ft.dwLowDateTime = 0x12345678;
@@ -421,41 +421,41 @@ _PUBLIC_ bool mapitest_mapidump_contact(struct mapitest *mt)
 	props.lpProps = talloc_array(mt->mem_ctx, struct mapi_SPropValue, props.cValues);
 
 	props.lpProps[0].ulPropTag = PR_POSTAL_ADDRESS;
-	props.lpProps[0].value.lpszA = "P.O. Box 543, KTown";
+	props.lpProps[0].value.lpszA = (char *) "P.O. Box 543, KTown";
 
 	props.lpProps[1].ulPropTag = PR_STREET_ADDRESS;
-	props.lpProps[1].value.lpszA = "1 My Street, KTown";
+	props.lpProps[1].value.lpszA = (char *) "1 My Street, KTown";
 
 	props.lpProps[2].ulPropTag = PR_COMPANY_NAME;
-	props.lpProps[2].value.lpszA = "Dummy Company Pty Ltd";
+	props.lpProps[2].value.lpszA = (char *) "Dummy Company Pty Ltd";
 
 	props.lpProps[3].ulPropTag = PR_TITLE;
-	props.lpProps[3].value.lpszA = "Ms.";
+	props.lpProps[3].value.lpszA = (char *) "Ms.";
 
 	props.lpProps[4].ulPropTag = PR_COUNTRY;
-	props.lpProps[4].value.lpszA = "Australia";
+	props.lpProps[4].value.lpszA = (char *) "Australia";
 
 	props.lpProps[5].ulPropTag = PR_GIVEN_NAME;
-	props.lpProps[5].value.lpszA = "Konq.";
+	props.lpProps[5].value.lpszA = (char *) "Konq.";
 
 	props.lpProps[6].ulPropTag = PR_SURNAME;
-	props.lpProps[6].value.lpszA = "Dragoon";
+	props.lpProps[6].value.lpszA = (char *) "Dragoon";
 
 	props.lpProps[7].ulPropTag = PR_DEPARTMENT_NAME;
-	props.lpProps[7].value.lpszA = "Research and Marketing";
+	props.lpProps[7].value.lpszA = (char *) "Research and Marketing";
 
 	mapidump_contact(&props, "[dummy ID]");
 
 	props.lpProps[1].ulPropTag = PR_CONVERSATION_TOPIC;
-	props.lpProps[1].value.lpszA = "Contact Topic";
+	props.lpProps[1].value.lpszA = (char *) "Contact Topic";
 
 	mapidump_contact(&props, "[dummy ID]");
 
 	props.lpProps[0].ulPropTag = PidLidFileUnder;
-	props.lpProps[0].value.lpszA = "Card Label";
+	props.lpProps[0].value.lpszA = (char *) "Card Label";
 
 	props.lpProps[4].ulPropTag = PR_DISPLAY_NAME;
-	props.lpProps[4].value.lpszA = "Konqi Dragon";
+	props.lpProps[4].value.lpszA = (char *) "Konqi Dragon";
 
 	mapidump_contact(&props, "[dummy ID]");
 
@@ -488,13 +488,13 @@ _PUBLIC_ bool mapitest_mapidump_appointment(struct mapitest *mt)
 	props.lpProps[0].value.MVszA.strings[1].lppszA = "Contact Two Jr.";
 
 	props.lpProps[1].ulPropTag = PR_CONVERSATION_TOPIC;
-	props.lpProps[1].value.lpszA = "Dummy Appointment topic";
+	props.lpProps[1].value.lpszA = (char *) "Dummy Appointment topic";
 
 	props.lpProps[2].ulPropTag = PidLidTimeZoneDescription;
-	props.lpProps[2].value.lpszA = "AEDT";
+	props.lpProps[2].value.lpszA = (char *) "AEDT";
 
 	props.lpProps[3].ulPropTag = PidLidLocation;
-	props.lpProps[3].value.lpszA = "OpenChange Conference Room #3";
+	props.lpProps[3].value.lpszA = (char *) "OpenChange Conference Room #3";
 
 	props.lpProps[4].ulPropTag = PidLidBusyStatus;
 	props.lpProps[4].value.l = olTaskNotStarted;
@@ -536,25 +536,25 @@ _PUBLIC_ bool mapitest_mapidump_message(struct mapitest *mt)
 	props.lpProps = talloc_array(mt->mem_ctx, struct mapi_SPropValue, props.cValues);
 
 	props.lpProps[0].ulPropTag = PR_INTERNET_MESSAGE_ID;
-	props.lpProps[0].value.lpszA = "dummy-3535395fds@example.com";
+	props.lpProps[0].value.lpszA = (char *) "dummy-3535395fds@example.com";
 	
 	props.lpProps[1].ulPropTag = PR_CONVERSATION_TOPIC;
-	props.lpProps[1].value.lpszA = "Dummy Email Subject";
+	props.lpProps[1].value.lpszA = (char *) "Dummy Email Subject";
 
 	props.lpProps[2].ulPropTag = PR_BODY;
-	props.lpProps[2].value.lpszA = "This is the body of the email. It has two sentences.\n";
+	props.lpProps[2].value.lpszA = (char *) "This is the body of the email. It has two sentences.\n";
 
 	props.lpProps[3].ulPropTag = PR_SENT_REPRESENTING_NAME;
-	props.lpProps[3].value.lpszA = "The Sender <sender@example.com>";
+	props.lpProps[3].value.lpszA = (char *) "The Sender <sender@example.com>";
 
 	props.lpProps[4].ulPropTag = PR_DISPLAY_TO;
-	props.lpProps[4].value.lpszA = "The Recipient <to@example.com>";
+	props.lpProps[4].value.lpszA = (char *) "The Recipient <to@example.com>";
 
 	props.lpProps[5].ulPropTag = PR_DISPLAY_CC;
-	props.lpProps[5].value.lpszA = "Other Recipient <cc@example.com>";
+	props.lpProps[5].value.lpszA = (char *) "Other Recipient <cc@example.com>";
 
 	props.lpProps[6].ulPropTag = PR_DISPLAY_BCC;
-	props.lpProps[6].value.lpszA = "Ms. Anonymous <bcc@example.com>";
+	props.lpProps[6].value.lpszA = (char *) "Ms. Anonymous <bcc@example.com>";
 
 	props.lpProps[7].ulPropTag = PidTagPriority;
 	props.lpProps[7].value.l = 0;
@@ -627,7 +627,7 @@ _PUBLIC_ bool mapitest_mapidump_newmail(struct mapitest *mt)
 	notif.MID = 0xBADCAFEBEEF87625LL;
 	notif.MessageFlags = 0x20|0x2;
 	notif.UnicodeFlag = false;
-	notif.MessageClass.lpszA = "Dummy class";
+	notif.MessageClass.lpszA = (char *) "Dummy class";
 
 	mapidump_newmail(&notif, "[sep]");
 
@@ -776,7 +776,7 @@ _PUBLIC_ bool mapitest_mapidump_recipients(struct mapitest *mt)
 	SRow_addprop(&(resolved.aRow[0]), SPropValue);
 
 	SPropValue.ulPropTag = PR_GIVEN_NAME;
-	SPropValue.value.lpszA = "gname";
+	SPropValue.value.lpszA = (uint8_t *) "gname";
 	SRow_addprop(&(resolved.aRow[0]), SPropValue);
 
 	flaglist.cValues = 3;

--- a/utils/mapitest/modules/module_noserver.c
+++ b/utils/mapitest/modules/module_noserver.c
@@ -313,26 +313,26 @@ static bool mapitest_noserver_srowset_untagged(struct mapitest *mt)
 		referenceRowSet.aRow[rowNum].lpProps[1].ulPropTag = PR_BODY;
 		referenceRowSet.aRow[rowNum].lpProps[1].dwAlignPad = 0;
 	}
-	referenceRowSet.aRow[0].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[0].lpProps[1].value.lpszA = "Body of message 8";
-	referenceRowSet.aRow[1].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[1].lpProps[1].value.lpszA = "Body of message 9";
-	referenceRowSet.aRow[2].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[2].lpProps[1].value.lpszA = "Body of message 7";
-	referenceRowSet.aRow[3].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[3].lpProps[1].value.lpszA = "Body of message 6";
-	referenceRowSet.aRow[4].lpProps[0].value.lpszA = "MT Dummy4";
-	referenceRowSet.aRow[4].lpProps[1].value.lpszA = "Body of message 4";
-	referenceRowSet.aRow[5].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[5].lpProps[1].value.lpszA = "Body of message 5";
-	referenceRowSet.aRow[6].lpProps[0].value.lpszA = "MT Dummy3";
-	referenceRowSet.aRow[6].lpProps[1].value.lpszA = "Body of message 3";
-	referenceRowSet.aRow[7].lpProps[0].value.lpszA = "MT Dummy1";
-	referenceRowSet.aRow[7].lpProps[1].value.lpszA = "Body of message 1";
-	referenceRowSet.aRow[8].lpProps[0].value.lpszA = "MT Dummy2";
-	referenceRowSet.aRow[8].lpProps[1].value.lpszA = "Body of message 2";
-	referenceRowSet.aRow[9].lpProps[0].value.lpszA = "MT Dummy0";
-	referenceRowSet.aRow[9].lpProps[1].value.lpszA = "Body of message 0";
+	referenceRowSet.aRow[0].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[0].lpProps[1].value.lpszA = (uint8_t *) "Body of message 8";
+	referenceRowSet.aRow[1].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[1].lpProps[1].value.lpszA = (uint8_t *) "Body of message 9";
+	referenceRowSet.aRow[2].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[2].lpProps[1].value.lpszA = (uint8_t *) "Body of message 7";
+	referenceRowSet.aRow[3].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[3].lpProps[1].value.lpszA = (uint8_t *) "Body of message 6";
+	referenceRowSet.aRow[4].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy4";
+	referenceRowSet.aRow[4].lpProps[1].value.lpszA = (uint8_t *) "Body of message 4";
+	referenceRowSet.aRow[5].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[5].lpProps[1].value.lpszA = (uint8_t *) "Body of message 5";
+	referenceRowSet.aRow[6].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy3";
+	referenceRowSet.aRow[6].lpProps[1].value.lpszA = (uint8_t *) "Body of message 3";
+	referenceRowSet.aRow[7].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy1";
+	referenceRowSet.aRow[7].lpProps[1].value.lpszA = (uint8_t *) "Body of message 1";
+	referenceRowSet.aRow[8].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy2";
+	referenceRowSet.aRow[8].lpProps[1].value.lpszA = (uint8_t *) "Body of message 2";
+	referenceRowSet.aRow[9].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy0";
+	referenceRowSet.aRow[9].lpProps[1].value.lpszA = (uint8_t *) "Body of message 0";
 
 
 	/* compare result with reference rowset */
@@ -350,7 +350,7 @@ static bool mapitest_noserver_srowset_untagged(struct mapitest *mt)
 				return false;
 			}
 			/* check property values are as expected */
-			if (strcmp(rowSet.aRow[rowNum].lpProps[i].value.lpszA, referenceRowSet.aRow[rowNum].lpProps[i].value.lpszA) != 0) {
+			if (strcmp((const char *) rowSet.aRow[rowNum].lpProps[i].value.lpszA, (const char *) referenceRowSet.aRow[rowNum].lpProps[i].value.lpszA) != 0) {
 				mapitest_print(mt, "* %-40s: unexpected property value (%i/%i): %s\n", "SRowSet", rowNum, i, rowSet.aRow[rowNum].lpProps[i].value.lpszA);
 				return false;
 			}
@@ -408,44 +408,44 @@ static bool mapitest_noserver_srowset_tagged(struct mapitest *mt)
 		referenceRowSet.aRow[rowNum].lpProps[1].ulPropTag = PR_BODY;
 		referenceRowSet.aRow[rowNum].lpProps[1].dwAlignPad = 0;
 	}
-	referenceRowSet.aRow[0].lpProps[0].value.lpszA = "MT Dummy From";
+	referenceRowSet.aRow[0].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
 	referenceRowSet.aRow[0].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[0].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[1].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[1].lpProps[1].value.lpszA = "Body of message 5";
-	referenceRowSet.aRow[2].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[2].lpProps[1].value.lpszA = "Body of message 6";
-	referenceRowSet.aRow[3].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[3].lpProps[1].value.lpszA = "Body of message 7";
-	referenceRowSet.aRow[4].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[4].lpProps[1].value.lpszA = "Body of message 8";
-	referenceRowSet.aRow[5].lpProps[0].value.lpszA = "MT Dummy From";
-	referenceRowSet.aRow[5].lpProps[1].value.lpszA = "Body of message 9";
-	referenceRowSet.aRow[6].lpProps[0].value.lpszA = "MT Dummy0";
+	referenceRowSet.aRow[1].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[1].lpProps[1].value.lpszA = (uint8_t *) "Body of message 5";
+	referenceRowSet.aRow[2].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[2].lpProps[1].value.lpszA = (uint8_t *) "Body of message 6";
+	referenceRowSet.aRow[3].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[3].lpProps[1].value.lpszA = (uint8_t *) "Body of message 7";
+	referenceRowSet.aRow[4].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[4].lpProps[1].value.lpszA = (uint8_t *) "Body of message 8";
+	referenceRowSet.aRow[5].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy From";
+	referenceRowSet.aRow[5].lpProps[1].value.lpszA = (uint8_t *) "Body of message 9";
+	referenceRowSet.aRow[6].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy0";
 	referenceRowSet.aRow[6].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[6].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[7].lpProps[0].value.lpszA = "MT Dummy0";
-	referenceRowSet.aRow[7].lpProps[1].value.lpszA = "Body of message 0";
-	referenceRowSet.aRow[8].lpProps[0].value.lpszA = "MT Dummy1";
+	referenceRowSet.aRow[7].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy0";
+	referenceRowSet.aRow[7].lpProps[1].value.lpszA = (uint8_t *) "Body of message 0";
+	referenceRowSet.aRow[8].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy1";
 	referenceRowSet.aRow[8].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[8].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[9].lpProps[0].value.lpszA = "MT Dummy1";
-	referenceRowSet.aRow[9].lpProps[1].value.lpszA = "Body of message 1";
-	referenceRowSet.aRow[10].lpProps[0].value.lpszA = "MT Dummy2";
+	referenceRowSet.aRow[9].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy1";
+	referenceRowSet.aRow[9].lpProps[1].value.lpszA = (uint8_t *) "Body of message 1";
+	referenceRowSet.aRow[10].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy2";
 	referenceRowSet.aRow[10].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[10].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[11].lpProps[0].value.lpszA = "MT Dummy2";
-	referenceRowSet.aRow[11].lpProps[1].value.lpszA = "Body of message 2";
-	referenceRowSet.aRow[12].lpProps[0].value.lpszA = "MT Dummy3";
+	referenceRowSet.aRow[11].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy2";
+	referenceRowSet.aRow[11].lpProps[1].value.lpszA = (uint8_t *) "Body of message 2";
+	referenceRowSet.aRow[12].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy3";
 	referenceRowSet.aRow[12].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[12].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[13].lpProps[0].value.lpszA = "MT Dummy3";
-	referenceRowSet.aRow[13].lpProps[1].value.lpszA = "Body of message 3";
-	referenceRowSet.aRow[14].lpProps[0].value.lpszA = "MT Dummy4";
+	referenceRowSet.aRow[13].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy3";
+	referenceRowSet.aRow[13].lpProps[1].value.lpszA = (uint8_t *) "Body of message 3";
+	referenceRowSet.aRow[14].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy4";
 	referenceRowSet.aRow[14].lpProps[1].ulPropTag = PR_BODY_ERROR;
 	referenceRowSet.aRow[14].lpProps[1].value.err = MAPI_E_NOT_FOUND;
-	referenceRowSet.aRow[15].lpProps[0].value.lpszA = "MT Dummy4";
-	referenceRowSet.aRow[15].lpProps[1].value.lpszA = "Body of message 4";
+	referenceRowSet.aRow[15].lpProps[0].value.lpszA = (uint8_t *) "MT Dummy4";
+	referenceRowSet.aRow[15].lpProps[1].value.lpszA = (uint8_t *) "Body of message 4";
 
 	/* compare result with reference rowset */
 	for (rowNum = 0; rowNum < rowSet.cRows; ++rowNum) {
@@ -468,7 +468,7 @@ static bool mapitest_noserver_srowset_tagged(struct mapitest *mt)
 					return false;
 				}
 			} else {
-				if (strcmp(rowSet.aRow[rowNum].lpProps[i].value.lpszA, referenceRowSet.aRow[rowNum].lpProps[i].value.lpszA) != 0) {
+				if (strcmp((const char *) rowSet.aRow[rowNum].lpProps[i].value.lpszA, (const char *) referenceRowSet.aRow[rowNum].lpProps[i].value.lpszA) != 0) {
 					mapitest_print(mt, "* %-40s: unexpected property value (%i/%i): %s\n", "SRowSet", rowNum, i, rowSet.aRow[rowNum].lpProps[i].value.lpszA);
 					return false;
 				}
@@ -884,11 +884,11 @@ static bool mapitest_no_server_props_mv_string8(struct mapitest *mt)
 
 	// create and initialise stringarray
 	stringarray.cValues = 4;
-	stringarray.lppszA = talloc_array(mt->mem_ctx, const char*, stringarray.cValues);
-	stringarray.lppszA[0] = "Fedora";
-	stringarray.lppszA[1] = "FreeBSD";
-	stringarray.lppszA[2] = "OpenSolaris";
-	stringarray.lppszA[3] = "Debian";
+	stringarray.lppszA = talloc_array(mt->mem_ctx, uint8_t *, stringarray.cValues);
+	stringarray.lppszA[0] = (uint8_t *) "Fedora";
+	stringarray.lppszA[1] = (uint8_t *) "FreeBSD";
+	stringarray.lppszA[2] = (uint8_t *) "OpenSolaris";
+	stringarray.lppszA[3] = (uint8_t *) "Debian";
 
 	res = set_SPropValue_proptag(&propvalue, PT_MV_STRING8, &stringarray);
 	if (res == false) {

--- a/utils/mapitest/modules/module_nspi.c
+++ b/utils/mapitest/modules/module_nspi.c
@@ -97,7 +97,7 @@ _PUBLIC_ bool mapitest_nspi_QueryRows(struct mapitest *mt)
 	lpProp = talloc_zero(mem_ctx, struct PropertyValue_r);
 	lpProp->ulPropTag = PR_ACCOUNT;
 	lpProp->dwAlignPad = 0;
-	lpProp->value.lpszA = mt->mapi_ctx->session->profile->username;
+	lpProp->value.lpszA = (uint8_t *) mt->mapi_ctx->session->profile->username;
 
 	Filter.rt = RES_PROPERTY;
 	Filter.res.resProperty.relop = RES_PROPERTY;
@@ -160,7 +160,7 @@ _PUBLIC_ bool mapitest_nspi_SeekEntries(struct mapitest *mt)
 	
 	pTarget.ulPropTag = PR_DISPLAY_NAME;
 	pTarget.dwAlignPad = 0x0;
-	pTarget.value.lpszA = emsmdb->info.szDisplayName;
+	pTarget.value.lpszA = (uint8_t *) emsmdb->info.szDisplayName;
 
 	pPropTags = set_SPropTagArray(mem_ctx, 0x1, PR_ACCOUNT);
 	retval = nspi_SeekEntries(nspi_ctx, mem_ctx, SortTypeDisplayName, &pTarget, pPropTags, NULL, &RowSet);
@@ -176,7 +176,7 @@ _PUBLIC_ bool mapitest_nspi_SeekEntries(struct mapitest *mt)
 
 	pTarget.ulPropTag = PR_DISPLAY_NAME_UNICODE;
 	pTarget.dwAlignPad = 0x0;
-	pTarget.value.lpszA = emsmdb->info.szDisplayName;
+	pTarget.value.lpszA = (uint8_t *) emsmdb->info.szDisplayName;
 
 	pPropTags = set_SPropTagArray(mem_ctx, 0x1, PR_ACCOUNT);
 	retval = nspi_SeekEntries(nspi_ctx, mem_ctx, SortTypeDisplayName, &pTarget, pPropTags, NULL, &RowSet);
@@ -224,7 +224,7 @@ _PUBLIC_ bool mapitest_nspi_GetMatches(struct mapitest *mt)
 	lpProp = talloc_zero(mem_ctx, struct PropertyValue_r);
 	lpProp->ulPropTag = PR_ACCOUNT;
 	lpProp->dwAlignPad = 0;
-	lpProp->value.lpszA = mt->mapi_ctx->session->profile->username;
+	lpProp->value.lpszA = (uint8_t *) mt->mapi_ctx->session->profile->username;
 
 	Filter.rt = RES_PROPERTY;
 	Filter.res.resProperty.relop = RES_PROPERTY;
@@ -344,8 +344,8 @@ _PUBLIC_ bool mapitest_nspi_DNToMId(struct mapitest *mt)
 	nspi_ctx = (struct nspi_context *) mt->session->nspi->ctx;
 
 	pNames.Count = 0x1;
-	pNames.Strings = (const char **) talloc_array(mem_ctx, char *, 1);
-	pNames.Strings[0] = mt->mapi_ctx->session->profile->homemdb;
+	pNames.Strings = (uint8_t **) talloc_array(mem_ctx, uint8_t *, 1);
+	pNames.Strings[0] = (uint8_t *) mt->mapi_ctx->session->profile->homemdb;
 
 	MId = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 
@@ -454,8 +454,8 @@ _PUBLIC_ bool mapitest_nspi_GetProps(struct mapitest *mt)
 	nspi_ctx = (struct nspi_context *) mt->session->nspi->ctx;
 
 	pNames.Count = 0x1;
-	pNames.Strings = (const char **) talloc_array(mem_ctx, char *, 1);
-	pNames.Strings[0] = mt->mapi_ctx->session->profile->homemdb;
+	pNames.Strings = (uint8_t **) talloc_array(mem_ctx, uint8_t *, 1);
+	pNames.Strings[0] = (uint8_t *) mt->mapi_ctx->session->profile->homemdb;
 
 	MId = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 
@@ -593,7 +593,7 @@ _PUBLIC_ bool mapitest_nspi_ModProps(struct mapitest *mt)
 	lpProp = talloc_zero(mem_ctx, struct PropertyValue_r);
 	lpProp->ulPropTag = PR_ACCOUNT;
 	lpProp->dwAlignPad = 0;
-	lpProp->value.lpszA = mt->mapi_ctx->session->profile->username;
+	lpProp->value.lpszA = (uint8_t *) mt->mapi_ctx->session->profile->username;
 
 	Filter.rt = RES_PROPERTY;
 	Filter.res.resProperty.relop = RES_PROPERTY;
@@ -636,7 +636,7 @@ _PUBLIC_ bool mapitest_nspi_ModProps(struct mapitest *mt)
 	/* Build the SRow and SPropTagArray for NspiModProps */
 	pRow = talloc_zero(mem_ctx, struct PropertyRow_r);
 	modProp.ulPropTag = PR_OFFICE_LOCATION;
-	modProp.value.lpszA = "MT office location";
+	modProp.value.lpszA = (uint8_t *) "MT office location";
 	PropertyRow_addprop(pRow, modProp);
 
 	pPropTags = set_SPropTagArray(mem_ctx, 0x1, PR_OFFICE_LOCATION);
@@ -678,7 +678,7 @@ _PUBLIC_ bool mapitest_nspi_ModProps(struct mapitest *mt)
 	/* try to reset the office location back to the original value */
 	pRow = talloc_zero(mem_ctx, struct PropertyRow_r);
 	modProp.ulPropTag = PR_OFFICE_LOCATION;
-	modProp.value.lpszA = original_office_location;
+	modProp.value.lpszA = (uint8_t *) original_office_location;
 	PropertyRow_addprop(pRow, modProp);
 
 	retval = nspi_ModProps(nspi_ctx, mem_ctx, MIds->aulPropTag[0], pPropTags, pRow);

--- a/utils/mapitest/modules/module_oxcfold.c
+++ b/utils/mapitest/modules/module_oxcfold.c
@@ -915,7 +915,7 @@ _PUBLIC_ bool mapitest_oxcfold_SetSearchCriteria(struct mapitest *mt)
 
 	/* Step 5. Set properties on this search folder */
 	lpProps[0].ulPropTag = PR_CONTAINER_CLASS;
-	lpProps[0].value.lpszA = IPF_NOTE;
+	lpProps[0].value.lpszA = (uint8_t *) IPF_NOTE;
 	SetProps(&obj_searchdir, 0, lpProps, 1);
 	mapitest_print_retval(mt, "SetProps");
 	if (GetLastError() != MAPI_E_SUCCESS) {
@@ -1026,7 +1026,7 @@ _PUBLIC_ bool mapitest_oxcfold_GetSearchCriteria(struct mapitest *mt)
 
 	/* Step 5. Set properties on this search folder */
 	lpProps[0].ulPropTag = PR_CONTAINER_CLASS;
-	lpProps[0].value.lpszA = IPF_NOTE;
+	lpProps[0].value.lpszA = (uint8_t *) IPF_NOTE;
 	SetProps(&obj_searchdir, 0, lpProps, 1);
 	mapitest_print_retval(mt, "SetProps");
 	if (GetLastError() != MAPI_E_SUCCESS) {

--- a/utils/mapitest/modules/module_oxcmsg.c
+++ b/utils/mapitest/modules/module_oxcmsg.c
@@ -1483,7 +1483,7 @@ _PUBLIC_ bool mapitest_oxcmsg_GetValidAttachments(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = "Attachment 0";
+	attach[2].value.lpszA = (uint8_t *) "Attachment 0";
 	retval = SetProps(&obj_attach0, 0, attach, 3);
 	mapitest_print_retval_clean(mt, "SetProps", retval);
 	if (retval != MAPI_E_SUCCESS) {
@@ -1512,7 +1512,7 @@ _PUBLIC_ bool mapitest_oxcmsg_GetValidAttachments(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = "Attachment 1";
+	attach[2].value.lpszA = (uint8_t *) "Attachment 1";
 	retval = SetProps(&obj_attach1, 0, attach, 3);
 	mapitest_print_retval_clean(mt, "SetProps", retval);
 	if (retval != MAPI_E_SUCCESS) {

--- a/utils/mapitest/modules/module_oxcprpt.c
+++ b/utils/mapitest/modules/module_oxcprpt.c
@@ -205,7 +205,7 @@ _PUBLIC_ bool mapitest_oxcprpt_SetProps(struct mapitest *mt)
 	MAPIFreeBuffer(SPropTagArray);
 
 	if (cValues && lpProps[0].value.lpszA) {
-		mailbox = lpProps[0].value.lpszA;
+		mailbox = (const char *) lpProps[0].value.lpszA;
 		mapitest_print(mt, "* Step 2. Mailbox name = %s\n", mailbox);
 	} else {
 		mapitest_print(mt, MT_ERROR, "* Step 2 - GetProps: No mailbox name\n");
@@ -225,7 +225,7 @@ _PUBLIC_ bool mapitest_oxcprpt_SetProps(struct mapitest *mt)
 	retval = GetProps(&obj_store, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(new_mailbox, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(new_mailbox, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 2.2 - Check: NEW mailbox name - [SUCCESS] (%s)\n", lpProps[0].value.lpszA);
 		} else {
 			mapitest_print(mt, "* Step 2.2 - Check: NEW mailbox name [FAILURE]\n");
@@ -244,7 +244,7 @@ _PUBLIC_ bool mapitest_oxcprpt_SetProps(struct mapitest *mt)
 	retval = GetProps(&obj_store, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(mailbox, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(mailbox, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 3.2 - Check: OLD mailbox name [SUCCESS]\n");
 		} else {
 			mapitest_print(mt, "* Step 3.2 - Check: OLD mailbox name, [FAILURE]\n");
@@ -341,7 +341,7 @@ _PUBLIC_ bool mapitest_oxcprpt_DeleteProps(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.1. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -350,7 +350,7 @@ _PUBLIC_ bool mapitest_oxcprpt_DeleteProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.2. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -488,7 +488,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.1. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -497,7 +497,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.2. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -533,7 +533,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	retval = GetProps(&obj_target_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(targ_name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(targ_name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 6A - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -542,7 +542,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 6B - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -569,7 +569,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 8A - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -578,7 +578,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 8B - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -591,7 +591,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	MAPIFreeBuffer(SPropTagArray);
 	/* this one shouldn't be overwritten */
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(targ_name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(targ_name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 8C - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -601,7 +601,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	}
 	/* this one should be copied */
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 8D - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -611,7 +611,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	}
 	/* this one should be unchanged */
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 8E - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -636,7 +636,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 10A - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -645,7 +645,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 10B - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -658,7 +658,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	MAPIFreeBuffer(SPropTagArray);
 	/* this one should now be overwritten */
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 10C - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -668,7 +668,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	}
 	/* this one should be copied */
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 10D - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -678,7 +678,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	}
 	/* this one should be unchanged */
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 10E - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -718,7 +718,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 	retval = GetProps(&obj_target_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 12B - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -727,7 +727,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 12C - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -736,7 +736,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyProps(struct mapitest *mt)
 		}
 	}
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 12D - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -875,7 +875,7 @@ _PUBLIC_ bool mapitest_oxcprpt_Stream(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = MT_MAIL_ATTACH;
+	attach[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH;
 
 	retval = SetProps(&obj_attach, 0, attach, 3);
 	if (retval != MAPI_E_SUCCESS) {
@@ -1166,7 +1166,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyToStream(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = MT_MAIL_ATTACH;
+	attach[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH;
 
 	retval = SetProps(&obj_attach, 0, attach, 3);
 	if (retval != MAPI_E_SUCCESS) {
@@ -1232,7 +1232,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyToStream(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = MT_MAIL_ATTACH2;
+	attach[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH2;
 
 	retval = SetProps(&obj_attach2, 0, attach, 3);
 	if (retval != MAPI_E_SUCCESS) {
@@ -1442,7 +1442,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		goto cleanup;
 	}
 	lpProp[0].ulPropTag = PR_CONTAINER_CLASS;
-	lpProp[0].value.lpszA = "IPF.Note";
+	lpProp[0].value.lpszA = (uint8_t *) "IPF.Note";
 	retval = SetProps(&obj_ref_folder, 0, lpProp, 1);
 	mapitest_print_retval(mt, "SetProps");
 	if (retval != MAPI_E_SUCCESS) {
@@ -1483,7 +1483,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 4A - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1494,7 +1494,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 4B - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1505,7 +1505,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(dept,  (const char *) lpProps[2].value.lpszA, strlen( (const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 4C - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -1552,7 +1552,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	retval = GetProps(&obj_target_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(targ_name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(targ_name,  (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 6A - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1564,7 +1564,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 6B - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1594,7 +1594,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 8A - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1605,7 +1605,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 8B - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1620,7 +1620,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	MAPIFreeBuffer(SPropTagArray);
 	/* this one shouldn't be overwritten */
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(targ_name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(targ_name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 8C - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1632,7 +1632,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	/* this one should be copied */
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 8D - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1644,7 +1644,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	/* this one should be unchanged */
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 8E - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -1671,7 +1671,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	retval = GetProps(&obj_ref_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 10A - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1682,7 +1682,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 10B - Check: Reference props still good - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1697,7 +1697,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	MAPIFreeBuffer(SPropTagArray);
 	/* this one should now be overwritten */
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 10C - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1709,7 +1709,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	/* this one should be copied */
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 10D - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1721,7 +1721,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	/* this one should be unchanged */
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(targ_dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(targ_dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 10E - Check: Reference props copy - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -1759,7 +1759,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	retval = GetProps(&obj_target_message, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 12B - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1770,7 +1770,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(subject, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(subject, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 12C - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1781,7 +1781,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}
 	if (lpProps[2].value.lpszA) {
-		if (!strncmp(dept, lpProps[2].value.lpszA, strlen(lpProps[2].value.lpszA))) {
+		if (!strncmp(dept, (const char *) lpProps[2].value.lpszA, strlen((const char *) lpProps[2].value.lpszA))) {
 			mapitest_print(mt, "* Step 12D - Check: Reference props move - [SUCCESS] (%s)\n",
 				       lpProps[2].value.lpszA);
 		} else {
@@ -1804,7 +1804,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	lpProp[1].ulPropTag = PR_RENDERING_POSITION;
 	lpProp[1].value.l = 0;
 	lpProp[2].ulPropTag = PR_ATTACH_FILENAME;
-	lpProp[2].value.lpszA = MT_MAIL_ATTACH;
+	lpProp[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH;
 	retval = SetProps(&obj_ref_attach, 0, lpProp, 3);
 	mapitest_print_retval(mt, "SetProps");
 	if (retval != MAPI_E_SUCCESS) {
@@ -1826,7 +1826,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	lpProp[1].ulPropTag = PR_RENDERING_POSITION;
 	lpProp[1].value.l = 0;
 	lpProp[2].ulPropTag = PR_ATTACH_FILENAME;
-	lpProp[2].value.lpszA = MT_MAIL_ATTACH2;
+	lpProp[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH2;
 	retval = SetProps(&obj_targ_attach, 0, lpProp, 3);
 	mapitest_print_retval(mt, "SetProps");
 	if (retval != MAPI_E_SUCCESS) {
@@ -1859,7 +1859,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(MT_MAIL_ATTACH, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(MT_MAIL_ATTACH, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 16B - Check: Reference attachment props - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1878,7 +1878,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(MT_MAIL_ATTACH, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(MT_MAIL_ATTACH, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 16D - Check: Target attachment props - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1898,7 +1898,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		goto cleanup;
 	}
 	lpProp[0].ulPropTag = PR_CONTAINER_CLASS;
-	lpProp[0].value.lpszA = "IPF.Journal";
+	lpProp[0].value.lpszA = (uint8_t *) "IPF.Journal";
 	retval = SetProps(&obj_targ_folder, 0, lpProp, 1);
 	mapitest_print_retval(mt, "SetProps");
 	if (retval != MAPI_E_SUCCESS) {
@@ -1927,7 +1927,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(MT_DIRNAME_TOP, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(MT_DIRNAME_TOP, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 19B - Check: Reference folder props - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1938,7 +1938,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}	
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp("IPF.Note", lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp("IPF.Note", (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 19C - Check: Reference folder props - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -1957,7 +1957,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 	}
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp("MT Target Folder", lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp("MT Target Folder", (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 19E - Check: Target folder props - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -1968,7 +1968,7 @@ _PUBLIC_ bool mapitest_oxcprpt_CopyTo(struct mapitest *mt)
 		}
 	}	
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp("IPF.Note", lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp("IPF.Note", (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 19F - Check: Target folder props - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -2479,7 +2479,7 @@ _PUBLIC_ bool mapitest_oxcprpt_NoReplicate(struct mapitest *mt)
 	retval = GetProps(&obj_ref_folder, 0, SPropTagArray, &lpProps, &cValues);
 	MAPIFreeBuffer(SPropTagArray);
 	if (lpProps[0].value.lpszA) {
-		if (!strncmp(name, lpProps[0].value.lpszA, strlen(lpProps[0].value.lpszA))) {
+		if (!strncmp(name, (const char *) lpProps[0].value.lpszA, strlen((const char *) lpProps[0].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.1. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[0].value.lpszA);
 		} else {
@@ -2490,7 +2490,7 @@ _PUBLIC_ bool mapitest_oxcprpt_NoReplicate(struct mapitest *mt)
 		}
 	}
 	if (lpProps[1].value.lpszA) {
-		if (!strncmp(comment, lpProps[1].value.lpszA, strlen(lpProps[1].value.lpszA))) {
+		if (!strncmp(comment, (const char *) lpProps[1].value.lpszA, strlen((const char *) lpProps[1].value.lpszA))) {
 			mapitest_print(mt, "* Step 4.2. - Check: Reference props set - [SUCCESS] (%s)\n",
 				       lpProps[1].value.lpszA);
 		} else {
@@ -2620,7 +2620,7 @@ _PUBLIC_ bool mapitest_oxcprpt_WriteAndCommitStream(struct mapitest *mt)
 	attach[1].ulPropTag = PR_RENDERING_POSITION;
 	attach[1].value.l = 0;
 	attach[2].ulPropTag = PR_ATTACH_FILENAME;
-	attach[2].value.lpszA = MT_MAIL_ATTACH;
+	attach[2].value.lpszA = (uint8_t *) MT_MAIL_ATTACH;
 
 	retval = SetProps(&obj_attach, 0, attach, 3);
 	if (retval != MAPI_E_SUCCESS) {

--- a/utils/mapitest/modules/module_zentyal.c
+++ b/utils/mapitest/modules/module_zentyal.c
@@ -106,7 +106,7 @@ _PUBLIC_ bool mapitest_zentyal_1863(struct mapitest *mt)
 	lpProp = talloc_zero(mem_ctx, struct PropertyValue_r);
 	lpProp->ulPropTag = PR_ACCOUNT;
 	lpProp->dwAlignPad = 0;
-	lpProp->value.lpszA = talloc_strdup(lpProp, mt->profile->username);
+	lpProp->value.lpszA = (uint8_t *) talloc_strdup(lpProp, mt->profile->username);
 
 	Filter.rt = RES_PROPERTY;
 	Filter.res.resProperty.relop = RES_PROPERTY;
@@ -283,9 +283,9 @@ _PUBLIC_ bool mapitest_zentyal_1804(struct mapitest *mt)
 	/* PT_MV_STRING8 */
 	value.ulPropTag = PR_EMS_AB_PROXY_ADDRESSES;
 	value.value.MVszA.cValues = 2;
-	value.value.MVszA.lppszA = talloc_array(mt->mem_ctx, const char *, value.value.MVszA.cValues);
-	value.value.MVszA.lppszA[0] = "smtp:user@test.com";
-	value.value.MVszA.lppszA[1] = "X400:c=US;a= ;p=First Organizati;o=Exchange;s=test";
+	value.value.MVszA.lppszA = talloc_array(mt->mem_ctx, uint8_t *, value.value.MVszA.cValues);
+	value.value.MVszA.lppszA[0] = (uint8_t *) "smtp:user@test.com";
+	value.value.MVszA.lppszA[1] = (uint8_t *) "X400:c=US;a= ;p=First Organizati;o=Exchange;s=test";
 	PropertyRowSet_propcpy(mt->mem_ctx, RowSet, value);
 	/* PT_MV_UNICODE - same layout as PT_MV_STRING8 */
 	value.ulPropTag = PR_EMS_AB_PROXY_ADDRESSES_UNICODE;

--- a/utils/openchangeclient.c
+++ b/utils/openchangeclient.c
@@ -600,27 +600,27 @@ static bool set_external_recipients(TALLOC_CTX *mem_ctx, struct SRowSet *SRowSet
 
 	/* PR_GIVEN_NAME */
 	SPropValue.ulPropTag = PR_GIVEN_NAME_UNICODE;
-	SPropValue.value.lpszA = username;
+	SPropValue.value.lpszA = (uint8_t *) username;
 	SRow_addprop(&(SRowSet->aRow[last]), SPropValue);
 
 	/* PR_DISPLAY_NAME */
 	SPropValue.ulPropTag = PR_DISPLAY_NAME_UNICODE;
-	SPropValue.value.lpszA = username;
+	SPropValue.value.lpszA = (uint8_t *) username;
 	SRow_addprop(&(SRowSet->aRow[last]), SPropValue);
 
 	/* PR_7BIT_DISPLAY_NAME */
 	SPropValue.ulPropTag = PR_7BIT_DISPLAY_NAME_UNICODE;
-	SPropValue.value.lpszA = username;
+	SPropValue.value.lpszA = (uint8_t *) username;
 	SRow_addprop(&(SRowSet->aRow[last]), SPropValue);
 
 	/* PR_SMTP_ADDRESS */
 	SPropValue.ulPropTag = PR_SMTP_ADDRESS_UNICODE;
-	SPropValue.value.lpszA = username;
+	SPropValue.value.lpszA = (uint8_t *) username;
 	SRow_addprop(&(SRowSet->aRow[last]), SPropValue);
 
 	/* PR_ADDRTYPE */
 	SPropValue.ulPropTag = PR_ADDRTYPE_UNICODE;
-	SPropValue.value.lpszA = "SMTP";
+	SPropValue.value.lpszA = (uint8_t *) "SMTP";
 	SRow_addprop(&(SRowSet->aRow[last]), SPropValue);
 
 	SetRecipientType(&(SRowSet->aRow[last]), RecipClass);
@@ -932,7 +932,7 @@ static enum MAPISTATUS openchangeclient_sendmail(TALLOC_CTX *mem_ctx,
 			printf("Sending %s:\n", oclient->attach[i].filename);
 			props_attach[2].value.lpszW = get_filename(oclient->attach[i].filename);
 			props_attach[3].ulPropTag = PR_ATTACH_CONTENT_ID;
-			props_attach[3].value.lpszA = get_filename(oclient->attach[i].filename);
+			props_attach[3].value.lpszA = (uint8_t *) get_filename(oclient->attach[i].filename);
 			count_props_attach = 4;
 
 			/* SetProps */
@@ -1026,7 +1026,7 @@ static bool openchangeclient_deletemail(TALLOC_CTX *mem_ctx,
 		len = strlen(oclient->subject);
 
 		for (i = 0; i < count_rows; i++) {
-			if (!strncmp(SRowSet.aRow[i].lpProps[4].value.lpszA, oclient->subject, len)) {
+			if (!strncmp((const char *) SRowSet.aRow[i].lpProps[4].value.lpszA, oclient->subject, len)) {
 				id_messages[count_messages] = SRowSet.aRow[i].lpProps[1].value.d;
 				count_messages++;
 			}
@@ -1587,7 +1587,7 @@ static const char *get_container_class(TALLOC_CTX *mem_ctx, mapi_object_t *paren
 		errno = 0;
 		return IPF_NOTE;
 	}
-	return lpProps[0].value.lpszA;
+	return (const char *) lpProps[0].value.lpszA;
 }
 
 static bool get_child_folders(TALLOC_CTX *mem_ctx, mapi_object_t *parent, mapi_id_t folder_id, int count)


### PR DESCRIPTION
This has the following _building_ dependency: https://github.com/zentyal/samba/pull/6

The fixes don't assume samba's DOS encoding anymore. Instead UNIX encoding is used and DOS character set checks removed.