### PR TITLE
Improvements over SyncImportReadStateChanges OXCFXICS ROP

### DIFF
--- a/exchange.idl
+++ b/exchange.idl
@@ -3618,14 +3618,20 @@ System Attendant Private Interface
 
 	/*************************/
 	/* EcDoRpc Function 0x80 */
-	typedef [public,flag(NDR_NOALIGN)] struct {
+	typedef [public, noprint, flag(NDR_NOALIGN)] struct {
 		uint16		MessageIdSize;
 		uint8		MessageId[MessageIdSize];
 		boolean8	MarkAsRead;
 	} MessageReadState;
 
-	typedef [flag(NDR_NOALIGN)] struct {
-		[subcontext(2),flag(NDR_REMAINING|NDR_NOALIGN)] DATA_BLOB MessageReadStates;
+	typedef [nopull, nopush, noprint, flag(NDR_NOALIGN)] struct {
+		[range(0,4000)] uint32	  cValues;
+		[size_is(cValues)] MessageReadState *lpMessageReadState;
+	} MessageReadStateArray;
+
+	typedef [public, noprint, flag(NDR_NOALIGN)] struct {
+		uint16									     MessageReadStateSize;
+		[subcontext(0), subcontext_size(MessageReadStateSize)] MessageReadStateArray MessageReadStates;
 	} SyncImportReadStateChanges_req;
 
 	typedef [flag(NDR_NOALIGN)] struct {

--- a/libmapi/FXICS.c
+++ b/libmapi/FXICS.c
@@ -3,6 +3,7 @@
 
    Copyright (C) Julien Kerihuel 2007-2011.
    Copyright (C) Brad Hards <bradh@openchange.org> 2010-2011.
+   Copyright (C) Enrique J. Hernández 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -20,6 +21,8 @@
 
 #include "libmapi/libmapi.h"
 #include "libmapi/libmapi_private.h"
+
+#include <gen_ndr/ndr_exchange.h>
 
 
 /**
@@ -1596,4 +1599,106 @@ _PUBLIC_ enum MAPISTATUS ICSSyncGetTransferState(mapi_object_t *obj, mapi_object
 	talloc_free(mem_ctx);
 
 	return MAPI_E_SUCCESS;
+}
+
+/**
+   \details Import message read state changes.
+
+   \param collector the ICS collector to use to upload changes
+   \param message_ids the message XIDs using Binary_r type to import the read state
+   \param read_states the values specify whether to mark the message
+   as read (true) or unread (false)
+   \param messages_num the number of messages to change the read state
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error.
+
+   \note Developers may also call GetLastError() to retrieve the last
+   MAPI error code. Possible MAPI error codes are:
+   - MAPI_E_NOT_INITIALIZED: MAPI subsystem has not been initialized
+   - MAPI_E_INVALID_PARAMETER: one of the function parameters is
+     invalid
+   - MAPI_E_CALL_FAILED: A network problem was encountered during the
+   transaction
+   - MAPI_E_NOT_ENOUGH_MEMORY: If any dynamic memory allocated
+   did not succeed
+ */
+_PUBLIC_ enum MAPISTATUS SyncImportReadStateChanges(mapi_object_t *collector,
+						    struct Binary_r *message_ids,
+						    bool *read_states,
+						    uint16_t messages_num)
+{
+	struct EcDoRpc_MAPI_REQ		       *mapi_req;
+	enum MAPISTATUS			       retval;
+	struct mapi_request		       *mapi_request;
+	struct mapi_response		       *mapi_response;
+	struct mapi_session		       *session;
+	NTSTATUS			       status;
+	size_t				       i;
+	struct SyncImportReadStateChanges_req  request;
+	TALLOC_CTX			       *local_mem_ctx;
+	uint8_t				       logon_id = 0;
+	uint32_t			       size = 0;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!collector, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!message_ids, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!read_states, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(messages_num == 0, MAPI_E_INVALID_PARAMETER, NULL);
+
+	session = mapi_object_get_session(collector);
+	OPENCHANGE_RETVAL_IF(!session, MAPI_E_INVALID_PARAMETER, NULL);
+
+	if ((retval = mapi_object_get_logon_id(collector, &logon_id)) != MAPI_E_SUCCESS) {
+		return retval;
+	}
+
+	local_mem_ctx = talloc_new(session);
+	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	/* Fill the SyncImportReadStateChanges operation */
+	request.MessageReadStateSize = 0;
+	request.MessageReadStates.cValues = messages_num;
+	request.MessageReadStates.lpMessageReadState = talloc_zero_array(local_mem_ctx, struct MessageReadState, messages_num);
+	OPENCHANGE_RETVAL_IF(!request.MessageReadStates.lpMessageReadState,
+			     MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	for (i = 0; i < messages_num; i++) {
+		request.MessageReadStates.lpMessageReadState[i].MessageIdSize = (uint16_t) message_ids[i].cb;
+		request.MessageReadStateSize += sizeof(uint16_t);
+		request.MessageReadStates.lpMessageReadState[i].MessageId = message_ids[i].lpb;
+		request.MessageReadStateSize += message_ids[i].cb;
+		request.MessageReadStates.lpMessageReadState[i].MarkAsRead = read_states[i];
+		request.MessageReadStateSize += sizeof(uint8_t);
+	}
+	size += request.MessageReadStateSize + sizeof(uint16_t);
+
+	/* Fill the MAPI_REQ structure */
+	mapi_req = talloc_zero(local_mem_ctx, struct EcDoRpc_MAPI_REQ);
+	OPENCHANGE_RETVAL_IF(!mapi_req, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_req->opnum = op_MAPI_SyncImportReadStateChanges;
+	mapi_req->logon_id = logon_id;
+	mapi_req->handle_idx = 0;
+	mapi_req->u.mapi_SyncImportReadStateChanges = request;
+	size += 5;
+
+	/* Fill the mapi_request structure */
+	mapi_request = talloc_zero(local_mem_ctx, struct mapi_request);
+	OPENCHANGE_RETVAL_IF(!mapi_request, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_request->mapi_len = size + sizeof (uint32_t) * 2;
+	mapi_request->length = (uint16_t)size;
+	mapi_request->mapi_req = mapi_req;
+	mapi_request->handles = talloc_array(local_mem_ctx, uint32_t, 2);
+	OPENCHANGE_RETVAL_IF(!mapi_request->handles, MAPI_E_NOT_ENOUGH_MEMORY,
+			     local_mem_ctx);
+	mapi_request->handles[0] = mapi_object_get_handle(collector);
+	mapi_request->handles[1] = 0xFFFFFFFF;
+
+	status = emsmdb_transaction_wrapper(session, local_mem_ctx, mapi_request, &mapi_response);
+	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), MAPI_E_CALL_FAILED, local_mem_ctx);
+	OPENCHANGE_RETVAL_IF(!mapi_response->mapi_repl, MAPI_E_CALL_FAILED, local_mem_ctx);
+	retval = mapi_response->mapi_repl->error_code;
+
+	talloc_free(mapi_response);
+	talloc_free(local_mem_ctx);
+
+	return retval;
 }

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -494,6 +494,7 @@ enum MAPISTATUS		ICSSyncUploadStateEnd(mapi_object_t *);
 enum MAPISTATUS		SetLocalReplicaMidsetDeleted(mapi_object_t *, const struct GUID, const uint8_t GlobalCountLow[6], const uint8_t GlobalCountHigh[6]);
 enum MAPISTATUS		ICSSyncOpenCollector(mapi_object_t *, bool, mapi_object_t *);
 enum MAPISTATUS		ICSSyncGetTransferState(mapi_object_t *, mapi_object_t *);
+enum MAPISTATUS		SyncImportReadStateChanges(mapi_object_t *, struct Binary_r *, bool *, uint16_t);
 
 /* The following public definitions come from libmapi/freebusy.c */
 enum MAPISTATUS		GetUserFreeBusyData(mapi_object_t *, const char *, struct SRow *);

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2907,3 +2907,123 @@ _PUBLIC_ void ndr_print_FILETIME(struct ndr_print *ndr, const char *name, const 
 
 	talloc_free(mem_ctx);
 }
+
+_PUBLIC_ void ndr_print_MessageReadState(struct ndr_print *ndr, const char *name, const struct MessageReadState *r)
+{
+	DATA_BLOB  guid_blob;
+	struct XID message_id;
+
+	ndr_print_struct(ndr, name, "MessageReadState");
+	if (r == NULL) { ndr_print_null(ndr); return; }
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		ndr->depth++;
+		ndr_print_uint16(ndr, "MessageIdSize", r->MessageIdSize);
+		if (r->MessageIdSize > 16) {
+			/* Generate the XID from the given array of bytes */
+			guid_blob.data = r->MessageId;
+			guid_blob.length = 16;
+			GUID_from_data_blob(&guid_blob, &message_id.NameSpaceGuid);
+			message_id.LocalId.length = r->MessageIdSize - 16;
+			message_id.LocalId.data = r->MessageId + 16;
+			ndr_print_XID(ndr, "MessageId", &message_id);
+		} else {
+			/* This is an error to happen */
+			ndr_print_array_uint8(ndr, "MessageId", r->MessageId, r->MessageIdSize);
+		}
+		ndr_print_uint8(ndr, "MarkAsRead", r->MarkAsRead);
+		ndr->depth--;
+		ndr->flags = _flags_save_STRUCT;
+	}
+}
+
+_PUBLIC_ void ndr_print_SyncImportReadStateChanges_req(struct ndr_print *ndr, const char *name, const struct SyncImportReadStateChanges_req *r)
+{
+	char			msg_num[1024];
+	int			i = 0;
+
+	ndr_print_struct(ndr, name, "SyncImportReadStateChanges_req");
+	if (r == NULL) { ndr_print_null(ndr); return; }
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		ndr->depth++;
+
+		ndr_print_uint16(ndr, "MessageReadStateSize", r->MessageReadStateSize);
+
+		for (i = 0; i < r->MessageReadStates.cValues; i++) {
+			snprintf(msg_num, 1024, "Message[%d]", i);
+			ndr_print_MessageReadState(ndr, msg_num, &r->MessageReadStates.lpMessageReadState[i]);
+		}
+		ndr->depth--;
+		ndr->flags = _flags_save_STRUCT;
+	}
+}
+
+_PUBLIC_ enum ndr_err_code ndr_push_MessageReadStateArray(struct ndr_push *ndr, int ndr_flags, const struct MessageReadStateArray *r)
+{
+	uint32_t cntr_lpMessageReadState_1;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PUSH_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			for (cntr_lpMessageReadState_1 = 0; cntr_lpMessageReadState_1 < r->cValues; cntr_lpMessageReadState_1++) {
+				NDR_CHECK(ndr_push_MessageReadState(ndr, NDR_SCALARS|NDR_BUFFERS,
+							       &r->lpMessageReadState[cntr_lpMessageReadState_1]));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}
+
+_PUBLIC_ enum ndr_err_code ndr_pull_MessageReadStateArray(struct ndr_pull *ndr, int ndr_flags, struct MessageReadStateArray *r)
+{
+	uint32_t cntr_lpMessageReadState_0;
+	TALLOC_CTX *_mem_save_lpMessageReadState_0;
+	uint32_t current_size;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			NDR_PULL_ALLOC(ndr, r->lpMessageReadState);
+			if (r->lpMessageReadState) {
+				_mem_save_lpMessageReadState_0 = NDR_PULL_GET_MEM_CTX(ndr);
+				NDR_PULL_SET_MEM_CTX(ndr, r->lpMessageReadState, 0);
+				NDR_CHECK(ndr_token_store(ndr, &ndr->array_size_list,
+							  &r->lpMessageReadState, ndr->data_size));
+				NDR_PULL_ALLOC_N(ndr, r->lpMessageReadState, 1);
+				cntr_lpMessageReadState_0 = 0;
+				current_size = 0;
+				while (current_size < ndr->data_size) {
+					NDR_CHECK(ndr_pull_MessageReadState(ndr, NDR_SCALARS|NDR_BUFFERS, &r->lpMessageReadState[cntr_lpMessageReadState_0]));
+					current_size += r->lpMessageReadState[cntr_lpMessageReadState_0].MessageIdSize + sizeof(uint16_t) + sizeof(uint8_t);
+					cntr_lpMessageReadState_0++;
+					r->lpMessageReadState = talloc_realloc(ndr->current_mem_ctx,
+									  r->lpMessageReadState,
+									  struct MessageReadState,
+									  cntr_lpMessageReadState_0 + 1);
+					if (!r->lpMessageReadState) {
+						return ndr_pull_error(ndr, NDR_ERR_ALLOC,
+								      "Alloc failed: %s\n",
+								      __location__);
+					}
+				}
+				if (current_size > 0 && cntr_lpMessageReadState_0 == 0) {
+					/* TODO: Use NDR_ERR_INCOMPLETE_BUFFER */
+					return NDR_ERR_BUFSIZE;
+				}
+				NDR_PULL_SET_MEM_CTX(ndr, _mem_save_lpMessageReadState_0, 0);
+				r->cValues = cntr_lpMessageReadState_0;
+			}
+			if (r->lpMessageReadState) {
+				NDR_CHECK(ndr_check_array_size(ndr, (void*)&r->lpMessageReadState, ndr->data_size));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -389,6 +389,9 @@ _PUBLIC_ uint32_t module_oxcfxics_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "SYNC-CONFIGURE-CONTENTS", "Configure ICS contents context for download", mapitest_oxcfxics_SyncConfigureContents);
 	mapitest_suite_add_test(suite, "SET-LOCAL-REPLICA-MIDSET-DELETED", "Reserve a range of local replica IDs", mapitest_oxcfxics_SetLocalReplicaMidsetDeleted);
 	mapitest_suite_add_test(suite, "SYNC-OPEN-COLLECTOR", "Test opening ICS upload collector", mapitest_oxcfxics_SyncOpenCollector);
+	mapitest_suite_add_test(suite, "SYNC-IMPORT-READ-STATE-CHANGES",
+				"Test mark as read a message",
+				mapitest_oxcfxics_SyncImportReadStateChanges);
 
 	mapitest_suite_register(mt, suite);
 


### PR DESCRIPTION
Several improvements over that rop:

* Read from NDR the SyncReadStateChanges payload
    * Easier to read and maintain SyncReadStateChanges server ROP
    * Read from the NDR dump the messages whose read flag is changed
* Mimetise Online mode for SetReadFlag on offline mode
* Adding checks on returned values
* Implement SyncReadStateChanges mapitest which required client side call in libmapi.
