### PR TITLE
 Improvements over SyncImportDeletes OXCFXICS ROP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ The descriptions should be useful and understandable for end users of OpenChange
 Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
 
 ## [unreleased]
-
+* Folder deletion using cached mode
 
 ## [2.4-zentyal9] - 2015-10-02
 

--- a/libmapi/FXICS.c
+++ b/libmapi/FXICS.c
@@ -1702,3 +1702,115 @@ _PUBLIC_ enum MAPISTATUS SyncImportReadStateChanges(mapi_object_t *collector,
 
 	return retval;
 }
+
+/**
+   \details Import message or folder deletions.
+
+   \param collector the ICS collector to use to upload changes
+   \param flags the sync import delete flags. Accepted values are in SyncImportDeletesFlags enum type
+   \param source_keys the GID array from which we import their deletions
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error.
+
+   \note Developers may also call GetLastError() to retrieve the last
+   MAPI error code. Possible MAPI error codes are:
+   - MAPI_E_NOT_INITIALIZED: MAPI subsystem has not been initialized
+   - MAPI_E_INVALID_PARAMETER: one of the function parameters is
+     invalid
+   - MAPI_E_CALL_FAILED: A network problem was encountered during the
+   transaction
+   - MAPI_E_NOT_ENOUGH_MEMORY: If any dynamic memory allocated
+   did not succeed
+ */
+_PUBLIC_ enum MAPISTATUS SyncImportDeletes(mapi_object_t *collector,
+					   uint8_t flags,
+					   struct BinaryArray_r *source_keys)
+{
+	bool				       ret;
+	struct EcDoRpc_MAPI_REQ		       *mapi_req;
+	enum MAPISTATUS			       retval;
+	struct mapi_request		       *mapi_request;
+	struct mapi_response		       *mapi_response;
+	struct mapi_session		       *session;
+	struct mapi_SBinaryArray	       property_values;
+	struct mapi_SPropValue		       *lp_prop;
+	NTSTATUS			       status;
+	size_t				       i;
+	struct SyncImportDeletes_req	       request;
+	TALLOC_CTX			       *local_mem_ctx;
+	uint8_t				       logon_id = 0;
+	uint32_t			       size = 0;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!collector, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!source_keys, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(source_keys->cValues < 1, MAPI_E_INVALID_PARAMETER, NULL);
+
+	session = mapi_object_get_session(collector);
+	OPENCHANGE_RETVAL_IF(!session, MAPI_E_INVALID_PARAMETER, NULL);
+
+	retval = mapi_object_get_logon_id(collector, &logon_id);
+	if (retval != MAPI_E_SUCCESS) {
+		return retval;
+	}
+
+	local_mem_ctx = talloc_new(session);
+	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	/* Fill the SyncImportDeletes operation */
+	request.Flags = flags;
+	size += sizeof(uint8_t);
+	request.PropertyValues.cValues = 1;
+	size += sizeof(uint16_t);
+
+	property_values.cValues = source_keys->cValues;
+	size += sizeof(uint32_t);
+	property_values.bin = talloc_zero_array(local_mem_ctx, struct SBinary_short, source_keys->cValues);
+	OPENCHANGE_RETVAL_IF(!property_values.bin, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	for (i = 0; i < property_values.cValues; i++) {
+		property_values.bin[i].cb = (uint16_t)source_keys->lpbin[i].cb;
+		size += sizeof(uint16_t);
+		property_values.bin[i].lpb = source_keys->lpbin[i].lpb;
+		size += source_keys->lpbin[i].cb;
+	}
+
+	lp_prop = talloc_zero(local_mem_ctx, struct mapi_SPropValue);
+	OPENCHANGE_RETVAL_IF(!lp_prop, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	size += sizeof(uint32_t);
+
+	ret = set_mapi_SPropValue_proptag(local_mem_ctx, lp_prop,
+					  PT_MV_BINARY, (const void*)&property_values);
+	OPENCHANGE_RETVAL_IF(!ret, MAPI_E_CALL_FAILED, local_mem_ctx);
+	request.PropertyValues.lpProps = lp_prop;
+
+	/* Fill the MAPI_REQ structure */
+	mapi_req = talloc_zero(local_mem_ctx, struct EcDoRpc_MAPI_REQ);
+	OPENCHANGE_RETVAL_IF(!mapi_req, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_req->opnum = op_MAPI_SyncImportDeletes;
+	mapi_req->logon_id = logon_id;
+	mapi_req->handle_idx = 0;
+	mapi_req->u.mapi_SyncImportDeletes = request;
+	size += 5;
+
+	/* Fill the mapi_request structure */
+	mapi_request = talloc_zero(local_mem_ctx, struct mapi_request);
+	OPENCHANGE_RETVAL_IF(!mapi_request, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_request->mapi_len = size + sizeof (uint32_t) * 2;
+	mapi_request->length = (uint16_t)size;
+	mapi_request->mapi_req = mapi_req;
+	mapi_request->handles = talloc_array(local_mem_ctx, uint32_t, 2);
+	OPENCHANGE_RETVAL_IF(!mapi_request->handles, MAPI_E_NOT_ENOUGH_MEMORY,
+			     local_mem_ctx);
+	mapi_request->handles[0] = mapi_object_get_handle(collector);
+	mapi_request->handles[1] = 0xFFFFFFFF;
+
+	status = emsmdb_transaction_wrapper(session, local_mem_ctx, mapi_request, &mapi_response);
+	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), MAPI_E_CALL_FAILED, local_mem_ctx);
+	OPENCHANGE_RETVAL_IF(!mapi_response->mapi_repl, MAPI_E_CALL_FAILED, local_mem_ctx);
+	retval = mapi_response->mapi_repl->error_code;
+
+	talloc_free(mapi_response);
+	talloc_free(local_mem_ctx);
+
+	return retval;
+}

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -495,6 +495,7 @@ enum MAPISTATUS		SetLocalReplicaMidsetDeleted(mapi_object_t *, const struct GUID
 enum MAPISTATUS		ICSSyncOpenCollector(mapi_object_t *, bool, mapi_object_t *);
 enum MAPISTATUS		ICSSyncGetTransferState(mapi_object_t *, mapi_object_t *);
 enum MAPISTATUS		SyncImportReadStateChanges(mapi_object_t *, struct Binary_r *, bool *, uint16_t);
+enum MAPISTATUS		SyncImportDeletes(mapi_object_t *, uint8_t, struct BinaryArray_r *);
 
 /* The following public definitions come from libmapi/freebusy.c */
 enum MAPISTATUS		GetUserFreeBusyData(mapi_object_t *, const char *, struct SRow *);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -332,6 +332,7 @@ enum mapistore_error  emsmdbp_object_get_fid_by_name(struct emsmdbp_context *, s
 enum MAPISTATUS       emsmdbp_object_create_folder(struct emsmdbp_context *, struct emsmdbp_object *, TALLOC_CTX *, uint64_t, struct SRow *, bool, struct emsmdbp_object **);
 enum mapistore_error  emsmdbp_object_open_folder(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 enum MAPISTATUS       emsmdbp_object_open_folder_by_fid(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
+enum MAPISTATUS       emsmdbp_object_open_folder_by_child_fid(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 
 struct emsmdbp_object *emsmdbp_object_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *parent_object);
 int emsmdbp_object_copy_properties(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -596,7 +596,7 @@ end:
 }
 
 /**
-   \details Return the folder object associated to specified folder identified
+   \details Return the folder object associated to specified folder identifier
 
    \param mem_ctx pointer to the memory context
    \param emsmdbp_ctx pointer to the emsmdbp context
@@ -652,6 +652,45 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_object_open_folder_by_fid(TALLOC_CTX *mem_ctx,
 			*folder_object_p = emsmdbp_object_folder_init(mem_ctx, emsmdbp_ctx, fid, NULL);
 			return MAPI_E_SUCCESS;
 		}
+	}
+
+	return retval;
+}
+
+/**
+   \details Return the folder object associated to the parent of the
+   specified folder identifier
+
+   \param mem_ctx pointer to the memory context where parent_folder_object_p will be allocated
+   \param emsmdbp_ctx pointer to the emsmdbp context
+   \param context_object pointer to current context object
+   \param fid pointer to the Folder Identifier to lookup its parent
+   \param [out] parent_folder_object_p location to store emsmdbp object on success
+
+   \return MAPISTATUS error code
+ */
+
+_PUBLIC_ enum MAPISTATUS emsmdbp_object_open_folder_by_child_fid(TALLOC_CTX *mem_ctx,
+								 struct emsmdbp_context *emsmdbp_ctx,
+								 struct emsmdbp_object *context_object,
+								 uint64_t fid,
+								 struct emsmdbp_object **parent_folder_object_p)
+{
+	uint64_t		parent_fid;
+	enum MAPISTATUS		retval;
+	struct emsmdbp_object	*mailbox_object;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!context_object, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!parent_folder_object_p, MAPI_E_INVALID_PARAMETER, NULL);
+
+	mailbox_object = emsmdbp_get_mailbox(context_object);
+	retval = emsmdbp_get_parent_fid(emsmdbp_ctx, mailbox_object, fid, &parent_fid);
+	if (retval == MAPI_E_SUCCESS) {
+		retval = emsmdbp_object_open_folder_by_fid(mem_ctx, emsmdbp_ctx, context_object, parent_fid,
+							   parent_folder_object_p);
 	}
 
 	return retval;

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2598,7 +2598,20 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	object_array = &request->PropertyValues.lpProps[0].value.MVbin;
+	/* Check PropertyValues is not NULL */
+	if (request->PropertyValues.cValues == 0) {
+		OC_DEBUG(1, "PropertyValues MUST be NOT null");
+		mapi_repl->error_code = MAPI_E_INVALID_PARAMETER;
+		goto end;
+	}
+
+	/* The object array is available at fixed 0 position */
+	object_array = (struct mapi_SBinaryArray *)get_mapi_SPropValue_data(&request->PropertyValues.lpProps[0]);
+	if (!object_array) {
+		OC_DEBUG(1, "The object array to delete must be in a MultipleBinary property");
+		mapi_repl->error_code = MAPI_E_INVALID_PARAMETER;
+		goto end;
+	}
 
 	local_mem_ctx = talloc_new(NULL);
 	if (!local_mem_ctx) {

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -392,6 +392,8 @@ _PUBLIC_ uint32_t module_oxcfxics_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "SYNC-IMPORT-READ-STATE-CHANGES",
 				"Test mark as read a message",
 				mapitest_oxcfxics_SyncImportReadStateChanges);
+	mapitest_suite_add_test(suite, "SYNC-IMPORT-MSG-DELETES", "Test import message deletions", mapitest_oxcfxics_SyncImportDeletesMsg);
+	mapitest_suite_add_test(suite, "SYNC-IMPORT-FOLDER-DELETES", "Test import folder deletions", mapitest_oxcfxics_SyncImportDeletesFolder);
 
 	mapitest_suite_register(mt, suite);
 

--- a/utils/mapitest/modules/module_oxcfxics.c
+++ b/utils/mapitest/modules/module_oxcfxics.c
@@ -1057,3 +1057,235 @@ cleanup:
 
 	return ret;
 }
+
+/**
+   \details Test the RopSynchronizationImportDeletes (0x74)
+   operation for messages.
+
+   This function:
+   -# Log on private message store
+   -# Create a test folder
+   -# Create a message and save it
+   -# Get the PidTagSourceKey
+   -# Open a sync collector context for contents
+   -# Import the deletions of that message
+   -# Check OpenMessage failed with MAPI_E_NOT_FOUND
+   -# Clean up
+ */
+_PUBLIC_ bool mapitest_oxcfxics_SyncImportDeletesMsg(struct mapitest *mt)
+{
+	struct Binary_r		*source_key;
+	struct BinaryArray_r	source_keys;
+	bool			ret = true;
+	enum MAPISTATUS		retval;
+	mapi_object_t		obj_htable;
+	mapi_object_t		obj_sync_collector;
+	mapi_object_t		collector_folder;
+	mapi_object_t		obj_message;
+	struct mt_common_tf_ctx	*context;
+	struct SPropValue	*lpProps;
+	struct SPropTagArray	*SPropTagArray;
+	uint32_t		c_values;
+
+	/* Step 1. Logon */
+	if (! mapitest_common_setup(mt, &obj_htable, NULL)) {
+		return false;
+	}
+
+	context = mt->priv;
+
+	/* Step 2. Create destfolder */
+	mapi_object_init(&collector_folder);
+	mapi_object_init(&obj_sync_collector);
+	mapi_object_init(&obj_message);
+	retval = CreateFolder(&(context->obj_test_folder), FOLDER_GENERIC,
+			      "ImportDeletes", NULL /*folder comment*/,
+			      OPEN_IF_EXISTS, &collector_folder);
+	mapitest_print_retval_clean(mt, "Create Folder", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 3. Create the message and save it */
+	ret = mapitest_common_message_create(mt, &collector_folder, &obj_message,
+					     MT_MAIL_SUBJECT);
+	mapitest_print_assert(mt, "mapitest_common_message_create", ret);
+	if (!ret) {
+		goto cleanup;
+	}
+
+	retval = SaveChangesMessage(&collector_folder, &obj_message, KeepOpenReadOnly);
+	mapitest_print_retval_clean(mt, "SaveChangesMessage", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 4. Get the PidTagSourceKey */
+	SPropTagArray = set_SPropTagArray(mt->mem_ctx, 0x1, PR_SOURCE_KEY);
+	retval = GetProps(&obj_message, 0, SPropTagArray, &lpProps, &c_values);
+	mapitest_print_retval_clean(mt, "GetProps - Source Key", retval);
+	if (c_values && (lpProps[0].ulPropTag & 0xFFFF) != PT_ERROR) {
+		source_key = (struct Binary_r *)get_SPropValue_data(&lpProps[0]);
+	} else {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 5. Open the collector */
+	retval = ICSSyncOpenCollector(&collector_folder, true, &obj_sync_collector);
+	mapitest_print_retval_clean(mt, "ICSSyncOpenCollector - Contents", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 6. Import deletes */
+	source_keys.cValues = 1;
+	source_keys.lpbin = source_key;
+	retval = SyncImportDeletes(&obj_sync_collector, SyncImportDeletes_HardDelete,
+				   &source_keys);
+	mapitest_print_retval_clean(mt, "SyncImportDeletes", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 7. Try to open the message again */
+	retval = OpenMessage(&context->obj_store, mapi_object_get_id(&collector_folder),
+			     mapi_object_get_id(&obj_message), &obj_message, 0x0);
+	mapitest_print_retval_clean(mt, "OpenMessage", retval);
+	if (retval != MAPI_E_NOT_FOUND) {
+		ret = false;
+		goto cleanup;
+	}
+
+cleanup:
+	/* Cleanup and release */
+	mapi_object_release(&obj_message);
+	mapi_object_release(&obj_sync_collector);
+	mapi_object_release(&collector_folder);
+	mapi_object_release(&obj_htable);
+	mapitest_common_cleanup(mt);
+
+	return ret;
+}
+
+/**
+   \details Test the RopSynchronizationImportDeletes (0x74)
+   operation for folders.
+   This function:
+   -# Log on private message store
+   -# Create a test folder
+   -# Get the PidTagSourceKey from that folder
+   -# Open Top Information Store folder
+   -# Open a sync collector context for contents on test folder
+   -# Import the deletions of that folder
+   -# Check OpenFolder failed with MAPI_E_NOT_FOUND for the deleted folder
+   -# Clean up
+ */
+_PUBLIC_ bool mapitest_oxcfxics_SyncImportDeletesFolder(struct mapitest *mt)
+{
+	struct Binary_r		*source_key;
+	struct BinaryArray_r	source_keys;
+	bool			ret = true;
+	enum MAPISTATUS		retval;
+	mapi_id_t		id_folder;
+	mapi_object_t		obj_htable;
+	mapi_object_t		obj_sync_collector;
+	mapi_object_t		test_folder, tis_folder;
+	mapi_object_t		obj_message;
+	struct mt_common_tf_ctx	*context;
+	struct SPropValue	*lpProps;
+	struct SPropTagArray	*SPropTagArray;
+	uint32_t		c_values;
+
+	/* Step 1. Logon */
+	if (! mapitest_common_setup(mt, &obj_htable, NULL)) {
+		return false;
+	}
+
+	context = mt->priv;
+
+	/* Step 2. Create a test folder */
+	mapi_object_init(&test_folder);
+	mapi_object_init(&tis_folder);
+	mapi_object_init(&obj_sync_collector);
+	mapi_object_init(&obj_message);
+	retval = CreateFolder(&(context->obj_test_folder), FOLDER_GENERIC,
+			      "ImportDeletes", NULL /*folder comment*/,
+			      OPEN_IF_EXISTS, &test_folder);
+	mapitest_print_retval_clean(mt, "Create Folder", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 3. Get the PidTagSourceKey */
+	SPropTagArray = set_SPropTagArray(mt->mem_ctx, 0x1, PR_SOURCE_KEY);
+	retval = GetProps(&test_folder, 0, SPropTagArray, &lpProps, &c_values);
+	mapitest_print_retval_clean(mt, "GetProps - Source Key", retval);
+	if (c_values && (lpProps[0].ulPropTag & 0xFFFF) != PT_ERROR) {
+		source_key = (struct Binary_r *)get_SPropValue_data(&lpProps[0]);
+	} else {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 4. Open Top Information Store folder */
+	retval = GetDefaultFolder(&(context->obj_store), &id_folder,
+				  olFolderTopInformationStore);
+	mapitest_print_retval(mt, "GetDefaultFolder");
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+	retval = OpenFolder(&(context->obj_store), id_folder, &tis_folder);
+	mapitest_print_retval(mt, "OpenFolder - Top Information Store");
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+
+	/* Step 5. Open the collector */
+	retval = ICSSyncOpenCollector(&tis_folder, true, &obj_sync_collector);
+	mapitest_print_retval_clean(mt, "ICSSyncOpenCollector - Contents", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 6. Import deletes */
+	source_keys.cValues = 1;
+	source_keys.lpbin = source_key;
+	retval = SyncImportDeletes(&obj_sync_collector,
+				   SyncImportDeletes_Hierarchy|SyncImportDeletes_HardDelete,
+				   &source_keys);
+	mapitest_print_retval_clean(mt, "SyncImportDeletes", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 7. Try to open the folder again */
+	retval = OpenFolder(&(context->obj_store), mapi_object_get_id(&test_folder),
+			    &test_folder);
+	mapitest_print_retval_clean(mt, "OpenFolder", retval);
+	if (retval != MAPI_E_NOT_FOUND) {
+		ret = false;
+		goto cleanup;
+	}
+
+cleanup:
+	/* Cleanup and release */
+	mapi_object_release(&obj_message);
+	mapi_object_release(&obj_sync_collector);
+	mapi_object_release(&test_folder);
+	mapi_object_release(&tis_folder);
+	mapi_object_release(&obj_htable);
+	mapitest_common_cleanup(mt);
+
+	return ret;
+}


### PR DESCRIPTION
* Implement SyncImportDeletes operation in client side
    * Along with mapitest to test it
* Folder deletion on cached mode now works
    * It was only working if the folder was at INBOX's level
* Added additional checks on SyncImportDeletes
