### PR TITLE
mapistore: all init error has the same log level

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -64,7 +64,7 @@ _PUBLIC_ struct mapistore_context *mapistore_init(TALLOC_CTX *mem_ctx, struct lo
 
 	private_dir = lpcfg_private_dir(lp_ctx);
 	if (!private_dir) {
-		OC_DEBUG(5, "private directory was not returned from configuration");
+		OC_DEBUG(0, "private directory was not returned from configuration");
 		return NULL;
 	}
 


### PR DESCRIPTION
Set the log level of a configuration error which makes
mapistore initialization fail to the same log level than
other fatal mapistore initialization errors.