### PR TITLE
Avoid crash because using session->uid

### DIFF
--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -244,7 +244,7 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 	if (h) {
 		session = mpm_session_find_by_uuid(&r->in.handle->uuid);
 
-		uuid_str = GUID_string(mem_ctx, &session->uuid);
+		uuid_str = GUID_string(mem_ctx, &r->in.handle->uuid);
 		OPENCHANGE_RETVAL_IF(!uuid_str, MAPI_E_NOT_ENOUGH_RESOURCES, NULL);
 		if (session) {
 			mpm_session_release(session);

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -206,7 +206,7 @@ static void dcesrv_NspiUnbind(struct dcesrv_call_state *dce_call,
 	if (h) {
 		session = mpm_session_find_by_uuid(&r->in.handle->uuid);
 
-		uuid_str = GUID_string(mem_ctx, &session->uuid);
+		uuid_str = GUID_string(mem_ctx, &r->in.handle->uuid);
 		DCESRV_NSP_RETURN_IF(!uuid_str, r, MAPI_E_NOT_ENOUGH_RESOURCES, NULL);
 		if (session) {
 			mpm_session_release(session);


### PR DESCRIPTION
session could not be found there so we must use r->in.handle->uuid instead