### PR TITLE
ocdb-mysql: Remove compilation warning

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -45,7 +45,6 @@ DSOOPT=-shared -fPIC
 CFLAGS=@CFLAGS@ @ENDIAN@ @COMPILER_OPTIONS_C@ @ASSERT_DEFINITION@ @SUBUNIT_CFLAGS@ @NDR_COLOR@  \
        -DDEFAULT_LDIF=\"$(datadir)/setup/profiles\"						\
        -DMAPISTORE_LDIF=\"$(datadir)/setup/mapistore\"						\
-       -DOPENCHANGEDB_DATA_DIR=\"$(datadir)/setup/openchangedb\"				\
        -DMAPISTORE_BACKEND_INSTALLDIR=\"$(libdir)/mapistore_backends\"				\
        -DLZXPRESS_DATADIR=\"$(datadir)/mapitest/lzxpress\"					\
        -DLZFU_DATADIR=\"$(datadir)/mapitest/lzfu\"						\

--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -3713,11 +3713,6 @@ static enum MAPISTATUS message_set_properties(TALLOC_CTX *parent_ctx,
 
 // ^ openchangedb message -----------------------------------------------------
 
-static const char *openchangedb_data_dir(void)
-{
-	return OPENCHANGEDB_DATA_DIR; // defined on compilation time
-}
-
 static int openchangedb_mysql_destructor(struct openchangedb_context *self)
 {
 	OC_DEBUG(5, "Destroying openchangedb mysql context\n");


### PR DESCRIPTION
After migration framework implemented, OPENCHANGEDB_DATA_DIR is not
longer needed.