### PR TITLE
openchange_user_cleanup.py: Fixed SQL identifer escapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Fixes
+* Fix openchange_user_cleanup.py bug with user names with non-alphanumerics characters
 
 ## [2.4-zentyal9] - 2015-10-02
 

--- a/script/openchange_user_cleanup.py
+++ b/script/openchange_user_cleanup.py
@@ -136,8 +136,10 @@ class ImapCleaner(object):
 
             print " [IMAP] Logged in as %s" % email
 
-            patterns = ["*(1)*", "Spam", "Sync Issues*", "Problemas de sincroni*",
-                        "Problèmes de synchronisation*"]
+            patterns = ["*(1)*", "Spam", "Sync Issues*", 
+                        "Problemas de sincroni*",
+                        "Problèmes de synchronisation*",
+                        "Synchronisierungsprobleme*"]
             for pattern in patterns:
                 code, data = client.list("", pattern)
                 if code != "OK":

--- a/script/openchange_user_cleanup.py
+++ b/script/openchange_user_cleanup.py
@@ -283,7 +283,7 @@ class SOGoCleaner(object):
         c = conn.cursor()
         tablename = "sogo_cache_folder_%s" % self._as_css_id(username)
         if not self.dry_run:
-            c.execute("DROP TABLE %s" % tablename)
+            c.execute("DROP TABLE `%s`" % tablename)
         print " [SOGo MySQL] Table %s deleted" % tablename
 
     def _get_connection_url(self):


### PR DESCRIPTION
SQL identifiers were not correctly escaped so the sentences could
fail in some cases. For example, users with hyphens, like 'user-a'.

If we want CHANGES.md: Fixed openchange_user_cleanup.py bug which some user names with non alphanumerics characters.