### PR TITLE
Fix conversion non-single rawidset with two elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Fixes
+
+* Return proper identifier states after performing upload operations
+that involves more than one message
+
 ### Improvements
 * Decode Multiple Value Unicode strings in FastTransfer buffer when dumping
 

--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -512,10 +512,9 @@ static struct idset *IDSET_make(TALLOC_CTX *mem_ctx, bool idbased, uint16_t base
 
 	current_globset->low = work_array[0];
 
-	if (single || length < 3) {
+	if (single) {
 		current_globset->high = work_array[length-1];
-	}
-	else {
+	} else {
 		last_consequent = exchange_globcnt(current_globset->low);
 		for (i = 1; i < length; i++) {
 			if ((exchange_globcnt(work_array[i]) != last_consequent) && (exchange_globcnt(work_array[i]) != (last_consequent + 1))) {

--- a/testsuite/libmapi/mapi_idset.c
+++ b/testsuite/libmapi/mapi_idset.c
@@ -262,32 +262,12 @@ START_TEST (test_RAWIDSET_convert_to_idset_one_id) {
 
 // v suite definition ---------------------------------------------------------
 
-static void tc_IDSET_parse_setup(void)
+static void tc_mapi_idset_setup(void)
 {
 	mem_ctx = talloc_new(talloc_autofree_context());
 }
 
-static void tc_IDSET_parse_teardown(void)
-{
-	talloc_free(mem_ctx);
-}
-
-static void tc_IDSET_includes_guid_glob_setup(void)
-{
-	mem_ctx = talloc_new(talloc_autofree_context());
-}
-
-static void tc_IDSET_remove_rawidset_setup(void)
-{
-	mem_ctx = talloc_new(talloc_autofree_context());
-}
-
-static void tc_IDSET_includes_guid_glob_teardown(void)
-{
-	mem_ctx = talloc_new(talloc_autofree_context());
-}
-
-static void tc_IDSET_remove_rawidset_teardown(void)
+static void tc_mapi_idset_teardown(void)
 {
 	talloc_free(mem_ctx);
 }
@@ -298,22 +278,22 @@ Suite *libmapi_idset_suite(void)
 	TCase *tc;
 
 	tc = tcase_create("IDSET_parse");
-	tcase_add_checked_fixture(tc, tc_IDSET_parse_setup, tc_IDSET_parse_teardown);
+	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_IDSET_parse);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("IDSET_includes_guid_glob");
-	tcase_add_checked_fixture(tc, tc_IDSET_includes_guid_glob_setup, tc_IDSET_includes_guid_glob_teardown);
+	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_IDSET_includes_guid_glob);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("IDSET_remove_rawidset");
-	tcase_add_checked_fixture(tc, tc_IDSET_remove_rawidset_setup, tc_IDSET_remove_rawidset_teardown);
+	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_IDSET_remove_rawidset);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("RAWIDSET_convert_to_idset");
-	tcase_add_checked_fixture(tc, tc_IDSET_parse_setup, tc_IDSET_parse_teardown);
+	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_RAWIDSET_convert_to_idset);
 	tcase_add_test(tc, test_RAWIDSET_convert_to_idset_one_id);
 	suite_add_tcase(s, tc);

--- a/testsuite/libmapi/mapi_idset.c
+++ b/testsuite/libmapi/mapi_idset.c
@@ -175,6 +175,89 @@ START_TEST (test_IDSET_remove_rawidset) {
 
 } END_TEST
 
+START_TEST (test_RAWIDSET_convert_to_idset) {
+	const uint64_t	       ids[] = {0xbc1c02000000,
+					0x130800000000};
+	const uint64_t	       consq_ids[] = {0xbd1c02000000,
+					      0xbe1c02000000};
+	struct GUID	       server_guid = GUID_random();
+	struct idset	       *new_idset;
+	int		       i;
+	struct rawidset	       *eid_set;
+	size_t		       ids_size = sizeof(ids)/sizeof(uint64_t);
+	size_t		       consq_ids_size = sizeof(consq_ids)/sizeof(uint64_t);
+
+	eid_set = RAWIDSET_make(mem_ctx, false, false);
+	ck_assert(eid_set != NULL);
+	for (i = 0; i < ids_size; i++) {
+		RAWIDSET_push_guid_glob(eid_set, &server_guid, ids[i]);
+	}
+
+	new_idset = RAWIDSET_convert_to_idset(mem_ctx, eid_set);
+	ck_assert(new_idset->idbased == false);
+	ck_assert(new_idset->single == false);
+	ck_assert(new_idset->next == NULL);
+	ck_assert_int_eq(new_idset->range_count, ids_size);
+
+	talloc_free(new_idset);
+
+	/* Unify ranges to return a single one */
+	eid_set->single = true;
+	new_idset = RAWIDSET_convert_to_idset(mem_ctx, eid_set);
+	ck_assert(new_idset->idbased == false);
+	ck_assert(new_idset->single == true);
+	ck_assert(new_idset->next == NULL);
+	ck_assert_int_eq(new_idset->range_count, 1);
+
+	talloc_free(new_idset);
+
+	/* Testing last consequent */
+	eid_set->single = false;
+	for (i = 0; i < consq_ids_size; i++) {
+		RAWIDSET_push_guid_glob(eid_set, &server_guid, consq_ids[i]);
+	}
+	new_idset = RAWIDSET_convert_to_idset(mem_ctx, eid_set);
+	ck_assert(new_idset->idbased == false);
+	ck_assert(new_idset->single == false);
+	ck_assert(new_idset->next == NULL);
+	ck_assert_int_eq(new_idset->range_count, 2);
+	ck_assert_int_ne(new_idset->ranges->next->low, new_idset->ranges->next->high);
+	ck_assert_int_eq(new_idset->ranges->next->high, consq_ids[consq_ids_size - 1]);
+
+} END_TEST
+
+START_TEST (test_RAWIDSET_convert_to_idset_one_id) {
+	const struct GUID server_guid = GUID_random();
+	struct idset	  *new_idset;
+	struct rawidset	  *eid_set;
+	const uint64_t	  id = 0x121201000000;
+
+	eid_set = RAWIDSET_make(mem_ctx, false, false);
+	ck_assert(eid_set != NULL);
+	RAWIDSET_push_guid_glob(eid_set, &server_guid, id);
+
+	new_idset = RAWIDSET_convert_to_idset(mem_ctx, eid_set);
+	ck_assert(new_idset->idbased == false);
+	ck_assert(new_idset->single == false);
+	ck_assert(new_idset->next == NULL);
+	ck_assert_int_eq(new_idset->range_count, 1);
+	ck_assert_int_eq(new_idset->ranges->low, id);
+	ck_assert_int_eq(new_idset->ranges->high, id);
+
+	talloc_free(new_idset);
+
+	/* Now with as a single rawidset */
+	eid_set->single = true;
+	new_idset = RAWIDSET_convert_to_idset(mem_ctx, eid_set);
+	ck_assert(new_idset->idbased == false);
+	ck_assert(new_idset->single == true);
+	ck_assert(new_idset->next == NULL);
+	ck_assert_int_eq(new_idset->range_count, 1);
+	ck_assert_int_eq(new_idset->ranges->low, id);
+	ck_assert_int_eq(new_idset->ranges->high, id);
+
+} END_TEST
+
 // ^ unit tests ---------------------------------------------------------------
 
 // v suite definition ---------------------------------------------------------
@@ -227,6 +310,12 @@ Suite *libmapi_idset_suite(void)
 	tc = tcase_create("IDSET_remove_rawidset");
 	tcase_add_checked_fixture(tc, tc_IDSET_remove_rawidset_setup, tc_IDSET_remove_rawidset_teardown);
 	tcase_add_test(tc, test_IDSET_remove_rawidset);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("RAWIDSET_convert_to_idset");
+	tcase_add_checked_fixture(tc, tc_IDSET_parse_setup, tc_IDSET_parse_teardown);
+	tcase_add_test(tc, test_RAWIDSET_convert_to_idset);
+	tcase_add_test(tc, test_RAWIDSET_convert_to_idset_one_id);
 	suite_add_tcase(s, tc);
 
 	return s;


### PR DESCRIPTION
Treating non-single two element rawidset likewise bigger idsets.

A rawidset with two globcnt were treated as single one with apparently no reason for this.

We have removed that special case and create unit tests for testing `RAWIDSET_convert_to_idset` function.

This was causing returning a bad MetaIdsetGiven when syncing the transfer state after performing operations where more than one message were involved and those messages were non-consecutive ones.