### PR TITLE
Improving idset management on upload operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Fixes
+* Returning only affected change numbers after uploading changes
+that involves several messages
+
 ### Improvements
 * Decode Multiple Value Unicode strings in FastTransfer buffer when dumping
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ## [unreleased]
 
 ### Fixes
+* Do not return invalid GLOBSET range of identifiers if the first operation
+of a folder (no data in client) is an upload.
 * Returning only affected change numbers after uploading changes
 that involves several messages
 

--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -504,7 +504,7 @@ static struct idset *IDSET_make(TALLOC_CTX *mem_ctx, bool idbased, uint16_t base
 	qsort(work_array, length, sizeof(uint64_t), IDSET_globcnt_compar);
 
 	if (length == 2) {
-		OC_DEBUG(5, "work_array[0]: %.16Lx, %.16Lx", (unsigned long long) work_array[0], (unsigned long long) work_array[1]);
+		OC_DEBUG(5, "work_array [0x%" PRIx64 ", 0x%" PRIx64 " ...]", work_array[0], work_array[1]);
 		if (work_array[0] != array[0]) {
 			OC_DEBUG(5, "elements were reordered");
 		}

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -3681,6 +3681,13 @@ static enum MAPISTATUS oxcfxics_ndr_push_transfer_state(struct ndr_push *ndr, co
 	sync_data->cnset_seen_fai = RAWIDSET_make(sync_data, false, true);
 	sync_data->eid_set = RAWIDSET_make(sync_data, false, false);
 
+	if (synccontext->request.is_collector) {
+		/* We ensure we are returning every Change Number separately
+		   to avoid missing elements in next contents download */
+		sync_data->cnset_seen->single = false;
+		sync_data->cnset_seen_fai->single = false;
+	}
+
 	OC_DEBUG(5, "Get transfer state for fid: 0x%.16"PRIx64,
 		 synccontext_object->parent_object->object.folder->folderID);
 
@@ -3711,9 +3718,6 @@ static enum MAPISTATUS oxcfxics_ndr_push_transfer_state(struct ndr_push *ndr, co
 		if (synccontext->cnset_seen) {
 			synccontext->cnset_seen->single = false;
 		}
-		if (new_idset) {
-			new_idset->single = false;
-		}
 	}
 	old_idset = synccontext->cnset_seen;
 	synccontext->cnset_seen = IDSET_merge_idsets(synccontext, old_idset, new_idset);
@@ -3730,9 +3734,6 @@ static enum MAPISTATUS oxcfxics_ndr_push_transfer_state(struct ndr_push *ndr, co
 		if (synccontext->request.is_collector) {
 			if (synccontext->cnset_seen_fai) {
 				synccontext->cnset_seen_fai->single = false;
-			}
-			if (new_idset) {
-				new_idset->single = false;
 			}
 		}
 		old_idset = synccontext->cnset_seen_fai;


### PR DESCRIPTION
Fixing two possible source of sync issues after performing upload operations:

* Do not return invalid GLOBSET range of identifiers if the first operation of a folder (no data in client) is an upload.
* Returning only affected change numbers after uploading changes that involves several messages

I've also extended mapitest to assure my assumptions and verify the code. That has encouraged finding more bugs :).