### PR TITLE
Fix log level on OC_DEBUG wrapper

### DIFF
--- a/libmapi/oc_log.h
+++ b/libmapi/oc_log.h
@@ -56,7 +56,7 @@ enum oc_log_level {
  * This macro is a simple wrapper around oc_log() that adds the
  * source file name and line number to the message. */
 #define OC_DEBUG(priority, format, ...) \
-	oc_log (OC_LOG_DEBUG+(priority), __location__ "(%s): " format, __PRETTY_FUNCTION__, ## __VA_ARGS__)
+	oc_log (OC_LOG_INFO+(priority), __location__ "(%s): " format, __PRETTY_FUNCTION__, ## __VA_ARGS__)
 
 /* Write a log message.
  * Like in syslog, a trailing newline is *not* required. The library will add it


### PR DESCRIPTION
With this change, the log level set in samba configuration is honored in OC_DEBUG wrapper. Before this patch, if a developer sets the log level to 5, it requires a level 6 in samba configuration to be logged.

I think this should be rollbacked once OpenChange uses its own debugging system.