### PR TITLE
libmapi: Decoding GLOBSETs properly which have bitmask command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Fixes
+* Perform proper decoding of idsets which contain GLOBSETs encoded using bitmask command.
+That avoids sync issues when returning the new state after badly parsing incoming one.
 
 ## [2.4-zentyal11] - 2015-10-26
 

--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -190,10 +190,10 @@ static inline void GLOBSET_parser_do_bitmask(struct GLOBSET_parser *parser)
 	bool blank = false;
 
 	mask = parser->buffer.data[parser->buffer_position+1];
-	parser->buffer_position += 2;
 
 	additional.length = 1;
 	additional.data = parser->buffer.data + parser->buffer_position;
+	parser->buffer_position += 2;
 
 	combined = GLOBSET_parser_stack_combine(NULL, parser, &additional);
 	baseValue = GLOBSET_parser_range_value(combined);
@@ -207,11 +207,10 @@ static inline void GLOBSET_parser_do_bitmask(struct GLOBSET_parser *parser)
 		if (blank) {
 			if ((mask & bit)) {
 				blank = false;
-				lowValue = baseValue + ((uint64_t) (bit + 1) << 40);
+				lowValue = baseValue + ((uint64_t) (i + 1) << 40);
 				highValue = lowValue;
 			}
-		}
-		else {
+		} else {
 			if ((mask & bit) == 0) {
 				range = talloc_zero(parser, struct globset_range);
 				range->low = lowValue;
@@ -219,9 +218,8 @@ static inline void GLOBSET_parser_do_bitmask(struct GLOBSET_parser *parser)
 				DLIST_ADD_END(parser->ranges, range, void);
 				parser->range_count++;
 				blank = true;
-			}
-			else {
-				highValue = baseValue + ((uint64_t) (bit + 1) << 40);
+			} else {
+				highValue = baseValue + ((uint64_t) (i + 1) << 40);
 			}
 		}
 	}

--- a/testsuite/libmapi/mapi_idset.c
+++ b/testsuite/libmapi/mapi_idset.c
@@ -64,6 +64,52 @@ START_TEST (test_IDSET_parse) {
 
 } END_TEST
 
+START_TEST (test_IDSET_parse_bitmask_cmd) {
+	/* Test GLOBSET encoded using Bitmask command */
+	DATA_BLOB		bin;
+	struct idset		*res;
+	const uint8_t		case_0[] =
+		{0x5b, 0x74, 0xc8, 0x0f, 0x23, 0xe2, 0x1f, 0x4f, 0x82, 0x34, 0x40, 0xf0, 0xbe, 0xc4, 0x6e, 0x93,
+		 0x4, 0x0, 0x0, 0x0, 0x6, 0x52, 0x4d, 0x5e, 0x89, 0xe6,
+		 0x1, 0x89, 0x42, 0xe8, 0x2, 0x50, 0x50, 0x0};
+	/* Example from [MS-OXCFXICS] Section 3.1.5.4.3.1.3 */
+	const uint8_t		case_1[] =
+		{0x1, 0x0,
+		 0x5, 0x0, 0x0, 0x0, 0x6, 0x89,
+		 0x42, 0x1, 0xeb, 0x50, 0x0};
+	const size_t		cases_size[] = { sizeof(case_0)/sizeof(uint8_t),
+						 sizeof(case_1)/sizeof(uint8_t) };
+
+	bin.length = cases_size[0];
+	bin.data = (uint8_t *)case_0;
+	res = IDSET_parse(mem_ctx, bin, false);
+	ck_assert(res != NULL);
+	ck_assert_int_eq(res->idbased, false);
+	ck_assert_int_eq(res->single, false);
+	ck_assert_int_eq(res->range_count, 3);
+	ck_assert_int_eq(res->ranges->low, 0x5e4d06000000);
+	ck_assert_int_eq(res->ranges->high, 0xe68906000000);
+	ck_assert_int_eq(res->ranges->next->low, 0xe88906000000);
+	ck_assert_int_eq(res->ranges->next->high, res->ranges->next->low);
+	ck_assert_int_eq(res->ranges->next->next->low, 0xea8906000000);
+	ck_assert_int_eq(res->ranges->next->next->high, res->ranges->next->next->low);
+
+	bin.length = cases_size[1];
+	bin.data = (uint8_t *)case_1;
+	res = IDSET_parse(mem_ctx, bin, true);
+	ck_assert(res != NULL);
+	ck_assert_int_eq(res->idbased, true);
+	ck_assert_int_eq(res->single, false);
+	ck_assert_int_eq(res->range_count, 3);
+	ck_assert_int_eq(res->ranges->low, 0x018906000000);
+	ck_assert_int_eq(res->ranges->high, 0x038906000000);
+	ck_assert_int_eq(res->ranges->next->low, 0x058906000000);
+	ck_assert_int_eq(res->ranges->next->high, res->ranges->next->low);
+	ck_assert_int_eq(res->ranges->next->next->low, 0x078906000000);
+	ck_assert_int_eq(res->ranges->next->next->high, 0x098906000000);
+
+} END_TEST
+
 START_TEST (test_IDSET_includes_guid_glob) {
         struct GUID       server_guid = GUID_random();
         struct GUID       random_guid = GUID_random();
@@ -280,6 +326,7 @@ Suite *libmapi_idset_suite(void)
 	tc = tcase_create("IDSET_parse");
 	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_IDSET_parse);
+	tcase_add_test(tc, test_IDSET_parse_bitmask_cmd);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("IDSET_includes_guid_glob");


### PR DESCRIPTION
Two bugs were spotted:

* The *StartingValue* was set to a wrong value because the buffer_position
  was altered before stored additional data that is combined in memory
* The GLOBSET ranges were incorrectly set because the calculated
  value was based on the bit value, which checks the mask against, instead
  of the position in the loop.

Two unit tests were added that cover the 100% of the
`GLOBSET_parser_do_bitmask` code.

The consequence of this bug is described as follows:

Once an idset is incorrectly decoded for one of the fxics meta-properties,
when they are returned as the final result of an upload/download operation
in the FastTransfer Buffer, it returns an inconsistent idset with incorrect
GLOBSET ranges. For instance, having a folder whose identifiers the client
does not have leads to the client to stop syncing that folder.

See details on BITMASK command at [MS-OXCFXICS] Section 3.1.5.4.3.1.3.