### PR TITLE
Avoid aborting on IDSET parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Fixes
+* Do not abort on IDSET parsing but returning a format error
 
 ## [2.4-zentyal11] - 2015-10-26
 

--- a/testsuite/libmapi/mapi_idset.c
+++ b/testsuite/libmapi/mapi_idset.c
@@ -64,6 +64,36 @@ START_TEST (test_IDSET_parse) {
 
 } END_TEST
 
+START_TEST (test_IDSET_parse_invalid) {
+	DATA_BLOB		bin;
+	int			i;
+	struct idset		*res;
+	/* Invalid command */
+	const uint8_t		case_0[] =
+		{0x1, 0x0, 0xBA, 0x0, 0x0, 0x0};
+	/* Too many PUSH commands */
+	const uint8_t		case_1[] =
+		{0x1, 0x0, 0x5, 0x0, 0x0, 0x0, 0x1, 0x4,
+		 0x2, 0x19, 0x1a, 0x1, 0xaa, 0x52, 0x19, 0x1a, 0x50, 0x0};
+	const uint8_t		case_2[] =
+		{0x1, 0x0, 0x1, 0xa, 0x1, 0xb, 0x1, 0xc,
+		 0x1, 0xd, 0x1, 0xe, 0x2, 0xf, 0xe, 0x1,
+		 0xa2, 0x1, 0xa1, 0x52, 0x19, 0x1a, 0x50, 0x0};
+	const uint8_t		 *cases[] = {case_0, case_1, case_2};
+	const size_t		 cases_size[] = { sizeof(case_0)/sizeof(uint8_t),
+						  sizeof(case_1)/sizeof(uint8_t),
+						  sizeof(case_2)/sizeof(uint8_t) };
+	const size_t		 CASES_NUM = sizeof(cases)/sizeof(uint8_t*);
+
+	for (i = 0; i < CASES_NUM; i++) {
+		bin.length = cases_size[i];
+		bin.data = (uint8_t *) cases[i];
+		res = IDSET_parse(mem_ctx, bin, true);
+		ck_assert(res == NULL);
+	}
+
+} END_TEST
+
 START_TEST (test_IDSET_includes_guid_glob) {
         struct GUID       server_guid = GUID_random();
         struct GUID       random_guid = GUID_random();
@@ -280,6 +310,7 @@ Suite *libmapi_idset_suite(void)
 	tc = tcase_create("IDSET_parse");
 	tcase_add_checked_fixture(tc, tc_mapi_idset_setup, tc_mapi_idset_teardown);
 	tcase_add_test(tc, test_IDSET_parse);
+	tcase_add_test(tc, test_IDSET_parse_invalid);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("IDSET_includes_guid_glob");


### PR DESCRIPTION
There are times where the IDSET is big enough that the MAPI client is splitting upload of the state property into several `SyncUploadStreamStateContinue` requests making crash the server if the `dcerpc_mapiproxy:ndrdump = true` option is set to true.
