### PR TITLE
libmapi: Optimise idset data usage with consecutive ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [unreleased]
 
+### Improvements
+* Optimise idset data usage on downloading changes with consecutive ranges
 
 ## [2.4-zentyal11] - 2015-10-26
 


### PR DESCRIPTION
On downloading changes we are merging now into one GLOBSET range,
ranges that are consecutive when merging idsets.

See the following example for details:

    [0x8c2c03000000:0xeb2204000000]
    [0x5c2304000000:0x622304000000]

Merge with:

    [0x632304000000:0x632304000000]

It will produce the following idset:

    [0x8c2c03000000:0xeb2204000000]
    [0x5c2304000000:0x632304000000]

Added unit tests to `IDSET_merge_idsets` to avoid regressions that cover function `IDSET_compact_ranges`.