### PR TITLE
Reconnect LDAP pipes if broken

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 * Do not fail receiving an empty idset on SyncUploadStateStreamEnd
+* Reconnect broken LDAP connections
 
 ### Improvements
 * Give support to Autodiscover requests done by MS Remote Connectivity Analyzer

--- a/Makefile
+++ b/Makefile
@@ -812,6 +812,7 @@ mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION):	mapiproxy/libmapiproxy/dc
 							mapiproxy/libmapiproxy/modules.po			\
 							mapiproxy/libmapiproxy/fault_util.po			\
 							mapiproxy/util/mysql.po					\
+							mapiproxy/util/samdb.po					\
 							mapiproxy/util/schema_migration.po			\
 							mapiproxy/util/ccan/htable/htable.po			\
 							libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
@@ -964,6 +965,7 @@ mapiproxy/libmapistore.$(SHLIBEXT).$(PACKAGE_VERSION):  mapiproxy/libmapistore/m
 							mapiproxy/libmapistore/backends/indexing_tdb.po			\
 							mapiproxy/libmapistore/backends/indexing_mysql.po		\
 							mapiproxy/util/mysql.po						\
+							mapiproxy/util/samdb.po						\
 							mapiproxy/util/oc_memcached.po					\
 							mapiproxy/util/ccan/htable/htable.po				\
 							mapiproxy/util/ccan/hash/hash.po				\

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -200,7 +200,7 @@ struct mpm_session *mpm_session_find_by_uuid(struct GUID *);
 
 
 /* definition from util/samdb.c */
-int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
+int safe_ldb_search(struct ldb_context **ldb, TALLOC_CTX *mem_ctx,
 		    struct ldb_result **result, struct ldb_dn *base,
 		    enum ldb_scope scope, const char * const *attrs,
 		    const char *exp_fmt, ...) PRINTF_ATTRIBUTE(7,8);

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -198,6 +198,14 @@ bool mpm_session_cmp_sub(struct mpm_session *, struct server_id, uint32_t);
 bool mpm_session_cmp(struct mpm_session *, struct dcesrv_call_state *);
 struct mpm_session *mpm_session_find_by_uuid(struct GUID *);
 
+
+/* definition from util/samdb.c */
+int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
+		    struct ldb_result **result, struct ldb_dn *base,
+		    enum ldb_scope scope, const char * const *attrs,
+		    const char *exp_fmt, ...) PRINTF_ATTRIBUTE(7,8);
+
+
 struct openchangedb_context;
 
 /* definitions from openchangedb.c */

--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -169,6 +169,7 @@ _PUBLIC_ enum mapistore_error mapistore_set_connection_info(struct mapistore_con
 	mstore_ctx->conn_info->sam_ctx = sam_ctx;
 	mstore_ctx->conn_info->oc_ctx = oc_ctx;
 	(void) talloc_reference(mstore_ctx->conn_info, mstore_ctx->conn_info->oc_ctx);
+	(void) talloc_reference(mstore_ctx->conn_info, sam_ctx);
 	mstore_ctx->conn_info->username = talloc_strdup(mstore_ctx->conn_info, username);
 
 	return MAPISTORE_SUCCESS;

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -9,12 +9,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,17 +30,10 @@
 #include "dcesrv_exchange_emsmdb.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
 #include "mapiproxy/libmapiproxy/fault_util.h"
+#include "mapiproxy/util/samdb.h"
 
 #include <ldap_ndr.h>
 
-/* Expose samdb_connect prototype */
-struct ldb_context *samdb_connect(TALLOC_CTX *, struct tevent_context *,
-				  struct loadparm_context *,
-				  struct auth_session_info *,
-				  unsigned int);
-
-/* Single connection to samdb */
-static struct ldb_context *samdb_ctx = NULL;
 
 static struct GUID MagicGUID = {
 	.time_low = 0xbeefface,
@@ -51,40 +44,6 @@ static struct GUID MagicGUID = {
 };
 const struct GUID *const MagicGUIDp = &MagicGUID;
 
-/**
-   \details Initialize ldb_context to samdb, creates one for all emsmdbp
-   contexts
-
-   \param lp_ctx pointer to the loadparm context
- */
-static struct ldb_context *samdb_init(struct loadparm_context *lp_ctx)
-{
-	TALLOC_CTX		*mem_ctx;
-	struct tevent_context	*ev;
-	const char		*samdb_url;
-
-	if (samdb_ctx) return samdb_ctx;
-
-	mem_ctx = talloc_autofree_context();
-	ev = tevent_context_init(mem_ctx);
-	if (!ev) {
-		OC_PANIC(false, ("Fail to initialize tevent_context\n"));
-		return NULL;
-	}
-	tevent_loop_allow_nesting(ev);
-
-	/* Retrieve samdb url (local or external) */
-	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
-
-	if (!samdb_url) {
-		samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
-	} else {
-		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
-					      LDB_FLG_RECONNECT, samdb_url);
-	}
-
-	return samdb_ctx;
-}
 
 /**
    \details Release the MAPISTORE context used by EMSMDB provider
@@ -157,7 +116,7 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 	/* Save a pointer to the loadparm context */
 	emsmdbp_ctx->lp_ctx = lp_ctx;
 
-	emsmdbp_ctx->samdb_ctx = samdb_init(lp_ctx);
+	emsmdbp_ctx->samdb_ctx = samdb_init(emsmdbp_ctx);
 	if (!emsmdbp_ctx->samdb_ctx) {
 		talloc_free(mem_ctx);
 		OC_DEBUG(0, "Connection to \"sam.ldb\" failed\n");
@@ -266,10 +225,10 @@ _PUBLIC_ bool emsmdbp_verify_user(struct dcesrv_call_state *dce_call,
 
 	username = dcesrv_call_account_name(dce_call);
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
-			 ldb_binary_encode_string(emsmdbp_ctx, username));
+	ret = safe_ldb_search (emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			       ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			       LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
+			       ldb_binary_encode_string(emsmdbp_ctx, username));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -322,10 +281,10 @@ _PUBLIC_ bool emsmdbp_verify_userdn(struct dcesrv_call_state *dce_call,
 	/* Sanity Checks */
 	if (!legacyExchangeDN) return false;
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 ldb_binary_encode_string(emsmdbp_ctx, legacyExchangeDN));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
+			      ldb_binary_encode_string(emsmdbp_ctx, legacyExchangeDN));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -389,11 +348,11 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!recipient, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!row, MAPI_E_INVALID_PARAMETER, NULL);
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs,
-			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 ldb_binary_encode_string(mem_ctx, recipient));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, recipient_attrs,
+			      "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
+			      ldb_binary_encode_string(mem_ctx, recipient));
 
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -419,7 +378,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 			}
 
 			libmapiserver_push_property(mem_ctx,
-						    property, (const void *)data, &row->prop_values, 
+						    property, (const void *)data, &row->prop_values,
 						    row->layout, 0, 0);
 		}
 
@@ -491,7 +450,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 			break;
 		}
 		libmapiserver_push_property(mem_ctx,
-					    property, (const void *)data, &row->prop_values, 
+					    property, (const void *)data, &row->prop_values,
 					    row->layout, 0, 0);
 	}
 
@@ -650,11 +609,11 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_org_dn(struct emsmdbp_context *emsmdbp_ctx,
 	retval = emsmdbp_fetch_organizational_units(emsmdbp_ctx, emsmdbp_ctx, &org_name, NULL);
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, NULL);
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_config_basedn(emsmdbp_ctx->samdb_ctx),
-                         LDB_SCOPE_SUBTREE, NULL,
-                         "(&(objectClass=msExchOrganizationContainer)(cn=%s))",
-                         ldb_binary_encode_string(emsmdbp_ctx, org_name));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			      ldb_get_config_basedn(emsmdbp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, NULL,
+			      "(&(objectClass=msExchOrganizationContainer)(cn=%s))",
+			      ldb_binary_encode_string(emsmdbp_ctx, org_name));
 	talloc_free(org_name);
 
 	/* If the search failed */
@@ -695,11 +654,11 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_external_email(struct emsmdbp_context *emsm
 	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx->samdb_ctx, MAPI_E_NOT_INITIALIZED, NULL);
 	OPENCHANGE_RETVAL_IF(!email, MAPI_E_INVALID_PARAMETER, NULL);
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs,
-			 "(&(objectClass=user)(sAMAccountName=%s))",
-			 ldb_binary_encode_string(emsmdbp_ctx, emsmdbp_ctx->username));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, attrs,
+			      "(&(objectClass=user)(sAMAccountName=%s))",
+			      ldb_binary_encode_string(emsmdbp_ctx, emsmdbp_ctx->username));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
 		OC_DEBUG(5, "Couldn't find %s using ldb_search", emsmdbp_ctx->username);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -225,7 +225,7 @@ _PUBLIC_ bool emsmdbp_verify_user(struct dcesrv_call_state *dce_call,
 
 	username = dcesrv_call_account_name(dce_call);
 
-	ret = safe_ldb_search (emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search (&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			       ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			       LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
 			       ldb_binary_encode_string(emsmdbp_ctx, username));
@@ -281,7 +281,7 @@ _PUBLIC_ bool emsmdbp_verify_userdn(struct dcesrv_call_state *dce_call,
 	/* Sanity Checks */
 	if (!legacyExchangeDN) return false;
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
 			      ldb_binary_encode_string(emsmdbp_ctx, legacyExchangeDN));
@@ -348,7 +348,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!recipient, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!row, MAPI_E_INVALID_PARAMETER, NULL);
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, recipient_attrs,
 			      "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
@@ -609,7 +609,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_org_dn(struct emsmdbp_context *emsmdbp_ctx,
 	retval = emsmdbp_fetch_organizational_units(emsmdbp_ctx, emsmdbp_ctx, &org_name, NULL);
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, NULL);
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			      ldb_get_config_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, NULL,
 			      "(&(objectClass=msExchOrganizationContainer)(cn=%s))",
@@ -654,7 +654,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_external_email(struct emsmdbp_context *emsm
 	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx->samdb_ctx, MAPI_E_NOT_INITIALIZED, NULL);
 	OPENCHANGE_RETVAL_IF(!email, MAPI_E_INVALID_PARAMETER, NULL);
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, attrs,
 			      "(&(objectClass=user)(sAMAccountName=%s))",

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1374,7 +1374,7 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *mem_ctx,
 	object->object.mailbox->mailboxstore = mailboxstore;
 
 	object->object.mailbox->owner_EssDN = talloc_strdup(object->object.mailbox, essDN);
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, recipient_attrs, "legacyExchangeDN=%s",
 			      ldb_binary_encode_string(mem_ctx, object->object.mailbox->owner_EssDN));
@@ -2495,7 +2495,7 @@ static enum MAPISTATUS mapiserver_get_administrative_group_legacyexchangedn(TALL
 	retval = emsmdbp_fetch_organizational_units(mem_ctx, emsmdbp_ctx, NULL, &group_name);
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, NULL);
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			      basedn, LDB_SCOPE_SUBTREE, attrs,
 			      "(&(objectClass=msExchAdminGroup)(msExchDefaultAdminGroup=TRUE)(cn=%s))",
 			      ldb_binary_encode_string(mem_ctx, group_name));

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -10,12 +10,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,6 +34,7 @@
 #include "mapiproxy/libmapiproxy/fault_util.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
 #include "mapiproxy/libmapistore/mapistore_nameid.h"
+#include "mapiproxy/util/samdb.h"
 #include "libmapi/property_tags.h"
 #include "libmapi/property_altnames.h"
 
@@ -1373,10 +1374,10 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *mem_ctx,
 	object->object.mailbox->mailboxstore = mailboxstore;
 
 	object->object.mailbox->owner_EssDN = talloc_strdup(object->object.mailbox, essDN);
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "legacyExchangeDN=%s",
-			 ldb_binary_encode_string(mem_ctx, object->object.mailbox->owner_EssDN));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
+			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, recipient_attrs, "legacyExchangeDN=%s",
+			      ldb_binary_encode_string(mem_ctx, object->object.mailbox->owner_EssDN));
 	if (!ret && res->count == 1) {
 		accountName = ldb_msg_find_attr_as_string(res->msgs[0], "sAMAccountName", NULL);
 		if (accountName) {
@@ -2494,10 +2495,10 @@ static enum MAPISTATUS mapiserver_get_administrative_group_legacyexchangedn(TALL
 	retval = emsmdbp_fetch_organizational_units(mem_ctx, emsmdbp_ctx, NULL, &group_name);
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, NULL);
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 basedn, LDB_SCOPE_SUBTREE, attrs,
-			 "(&(objectClass=msExchAdminGroup)(msExchDefaultAdminGroup=TRUE)(cn=%s))",
-			 ldb_binary_encode_string(mem_ctx, group_name));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			      basedn, LDB_SCOPE_SUBTREE, attrs,
+			      "(&(objectClass=msExchAdminGroup)(msExchDefaultAdminGroup=TRUE)(cn=%s))",
+			      ldb_binary_encode_string(mem_ctx, group_name));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS) {

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -45,7 +45,7 @@ static void oxcmsg_fill_RecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context
 		goto smtp_recipient;
 	}
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			     ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			     LDB_SCOPE_SUBTREE, recipient_attrs,
 			     "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
@@ -730,7 +730,7 @@ static enum MAPISTATUS oxcmsg_resolve_partial_x500name(TALLOC_CTX *mem_ctx,
 	}
 
 	/* Step 1. Try to find out an account with x500dn we have */
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE,
 			      attrs, "legacyExchangeDN=%s", x500dn);
 	if (ret != LDB_SUCCESS || res->count != 1) {

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -9,12 +9,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,6 +30,7 @@
 #include "mapiproxy/dcesrv_mapiproxy.h"
 #include "mapiproxy/libmapiproxy/libmapiproxy.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
+#include "mapiproxy/util/samdb.h"
 #include "dcesrv_exchange_emsmdb.h"
 
 static void oxcmsg_fill_RecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context *emsmdbp_ctx, struct RecipientRow *row, struct mapistore_message_recipient *recipient, struct SPropTagArray *properties)
@@ -44,11 +45,11 @@ static void oxcmsg_fill_RecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context
 		goto smtp_recipient;
 	}
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs,
-			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 ldb_binary_encode_string(mem_ctx, recipient->username));
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
+			     ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
+			     LDB_SCOPE_SUBTREE, recipient_attrs,
+			     "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
+			     ldb_binary_encode_string(mem_ctx, recipient->username));
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {
 		OC_DEBUG(0, "record not found for %s\n", recipient->username);
@@ -398,9 +399,9 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 	mapistore = emsmdbp_is_mapistore(folder_object);
 	switch ((int)mapistore) {
 	case true:
-		ret = mapistore_folder_create_message(emsmdbp_ctx->mstore_ctx, contextID, 
-						      folder_object->backend_object, message_object, 
-						      messageID, mapi_req->u.mapi_CreateMessage.AssociatedFlag, 
+		ret = mapistore_folder_create_message(emsmdbp_ctx->mstore_ctx, contextID,
+						      folder_object->backend_object, message_object,
+						      messageID, mapi_req->u.mapi_CreateMessage.AssociatedFlag,
 						      &message_object->backend_object);
 		if (ret != MAPISTORE_SUCCESS) {
 			if (ret == MAPISTORE_ERR_DENIED) {
@@ -729,9 +730,9 @@ static enum MAPISTATUS oxcmsg_resolve_partial_x500name(TALLOC_CTX *mem_ctx,
 	}
 
 	/* Step 1. Try to find out an account with x500dn we have */
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
-			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE,
-			 attrs, "legacyExchangeDN=%s", x500dn);
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
+			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE,
+			      attrs, "legacyExchangeDN=%s", x500dn);
 	if (ret != LDB_SUCCESS || res->count != 1) {
 		/* no such user, just pass what we have */
 		username = x500dn;

--- a/mapiproxy/servers/default/emsmdb/oxcstor.c
+++ b/mapiproxy/servers/default/emsmdb/oxcstor.c
@@ -9,12 +9,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,6 +26,7 @@
  */
 
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/util/samdb.h"
 #include "mapiproxy/libmapiproxy/libmapiproxy.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
 #include "dcesrv_exchange_emsmdb.h"
@@ -65,7 +66,7 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!request->EssDN, MAPI_E_INVALID_PARAMETER, NULL);
 
 	/* Step 0. Retrieve user record */
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", request->EssDN);
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", request->EssDN);
 	OPENCHANGE_RETVAL_IF((ret || res->count != 1), ecUnknownUser, NULL);
 
 	/* Step 1. Retrieve username from record */

--- a/mapiproxy/servers/default/emsmdb/oxcstor.c
+++ b/mapiproxy/servers/default/emsmdb/oxcstor.c
@@ -66,7 +66,7 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!request->EssDN, MAPI_E_INVALID_PARAMETER, NULL);
 
 	/* Step 0. Retrieve user record */
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", request->EssDN);
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, mem_ctx, &res, ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx), LDB_SCOPE_SUBTREE, attrs, "legacyExchangeDN=%s", request->EssDN);
 	OPENCHANGE_RETVAL_IF((ret || res->count != 1), ecUnknownUser, NULL);
 
 	/* Step 1. Retrieve username from record */

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -319,7 +319,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetAddressTypes(TALLOC_CTX *mem_ctx,
 	ldb_dn_add_child_fmt(basedn, "CN=ADDRESSING");
 	ldb_dn_add_child_fmt(basedn, "CN=ADDRESS-TEMPLATES");
 
-	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res, basedn,
+	ret = safe_ldb_search(&emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res, basedn,
 			      LDB_SCOPE_SUBTREE, attrs, "CN=%x", emsmdbp_ctx->userLanguage);
 	talloc_free(basedn);
 	/* If the search failed */

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -9,12 +9,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,6 +26,7 @@
  */
 
 #include "mapiproxy/libmapiserver/libmapiserver.h"
+#include "mapiproxy/util/samdb.h"
 #include "dcesrv_exchange_emsmdb.h"
 
 static void oxomsg_mapistore_handle_message_relocation(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *old_message_object)
@@ -318,8 +319,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetAddressTypes(TALLOC_CTX *mem_ctx,
 	ldb_dn_add_child_fmt(basedn, "CN=ADDRESSING");
 	ldb_dn_add_child_fmt(basedn, "CN=ADDRESS-TEMPLATES");
 
-	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res, basedn,
-                         LDB_SCOPE_SUBTREE, attrs, "CN=%x", emsmdbp_ctx->userLanguage);
+	ret = safe_ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res, basedn,
+			      LDB_SCOPE_SUBTREE, attrs, "CN=%x", emsmdbp_ctx->userLanguage);
 	talloc_free(basedn);
 	/* If the search failed */
 	if (ret != LDB_SUCCESS) {

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -27,6 +27,7 @@
  */
 
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/util/samdb.h"
 #include "mapiproxy/libmapiproxy/fault_util.h"
 #include "dcesrv_exchange_nsp.h"
 
@@ -1391,9 +1392,9 @@ static void dcesrv_do_NspiResolveNamesW(struct dcesrv_call_state *dce_call,
 			goto failure;
 		}
 
-		ret = ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &ldb_res,
-				 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
-				 LDB_SCOPE_SUBTREE, recipient_attrs, "%s", filter);
+		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &ldb_res,
+				      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
+				      LDB_SCOPE_SUBTREE, recipient_attrs, "%s", filter);
 
 		/* Determine name resolution status and fetch object upon success */
 		if (ret != LDB_SUCCESS || ldb_res->count == 0) {

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -1392,7 +1392,7 @@ static void dcesrv_do_NspiResolveNamesW(struct dcesrv_call_state *dce_call,
 			goto failure;
 		}
 
-		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &ldb_res,
+		ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, mem_ctx, &ldb_res,
 				      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 				      LDB_SCOPE_SUBTREE, recipient_attrs, "%s", filter);
 

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -132,7 +132,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_account_info(TALLOC_CTX *mem_ctx,
 	struct ldb_result	*res = NULL;
 	const char * const	recipient_attrs[] = { "*", NULL };
 
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, mem_ctx, &res,
 			      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
 			      ldb_binary_encode_string(mem_ctx, username));
@@ -714,7 +714,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_fetch_attrs(TALLOC_CTX *mem_ctx, struct emsabp_c
 	ldb_dn = ldb_dn_new(mem_ctx, emsabp_ctx->samdb_ctx, dn);
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, NULL);
 
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn, LDB_SCOPE_BASE,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn, LDB_SCOPE_BASE,
 			      recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, NULL);
 
@@ -949,7 +949,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_HierarchyTable(TALLOC_CTX *mem_ctx, struct e
 	aRow_idx++;
 
 	/* Step 2. Retrieve the object pointed by addressBookRoots attribute: 'All Address Lists' */
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 			      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
 			      scope, recipient_attrs, "(addressBookRoots=*)");
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_CORRUPT_STORE, aRow);
@@ -962,7 +962,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_HierarchyTable(TALLOC_CTX *mem_ctx, struct e
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, aRow);
 
 	scope = LDB_SCOPE_BASE;
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
 			      scope, recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, aRow);
 
@@ -1230,7 +1230,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_dn(struct emsabp_context *emsabp_ctx, con
 	ldb_dn = ldb_dn_new(emsabp_ctx->mem_ctx, emsabp_ctx->samdb_ctx, dn);
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, NULL);
 
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
 			      LDB_SCOPE_BASE, recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, NULL);
 
@@ -1267,14 +1267,14 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_legacyExchangeDN(struct emsabp_context *e
 	OPENCHANGE_RETVAL_IF(!pbUseConfPartition, MAPI_E_INVALID_PARAMETER, NULL);
 
 	*pbUseConfPartition = true;
-	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+	ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 			      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
 			      ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
 		*pbUseConfPartition = false;
-		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+		ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 				      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 				      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
 				      ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
@@ -1312,7 +1312,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_ab_fetch_filter(TALLOC_CTX *mem_ctx,
 
 	if (!ContainerID) {
 		/* if GAL is requested */
-		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
+		ret = safe_ldb_search(&emsabp_ctx->samdb_ctx, mem_ctx, &res,
 				      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
 				      LDB_SCOPE_SUBTREE, recipient_attrs, "(globalAddressList=*)");
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_CORRUPT_STORE, NULL);

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -28,53 +28,12 @@
 
 #define TEVENT_DEPRECATED
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/util/samdb.h"
 #include "mapiproxy/libmapiproxy/fault_util.h"
 #include "dcesrv_exchange_nsp.h"
 #include "ldb.h"
 
-/* Expose samdb_connect prototype */
-struct ldb_context *samdb_connect(TALLOC_CTX *, struct tevent_context *,
-				  struct loadparm_context *,
-				  struct auth_session_info *,
-				  unsigned int);
 
-/* Single connection to samdb */
-static struct ldb_context *samdb_ctx = NULL;
-
-/**
-   \details Initialize ldb_context to samdb, creates one for all emsabp
-   contexts
-
-   \param lp_ctx pointer to the loadparm context
- */
-static struct ldb_context *samdb_init(struct loadparm_context *lp_ctx)
-{
-	TALLOC_CTX		*mem_ctx;
-	struct tevent_context	*ev;
-	const char		*samdb_url;
-
-	if (samdb_ctx) return samdb_ctx;
-
-	mem_ctx = talloc_autofree_context();
-	ev = tevent_context_init(mem_ctx);
-	if (!ev) {
-		OC_PANIC(false, ("Fail to initialize tevent_context\n"));
-		return NULL;
-	}
-	tevent_loop_allow_nesting(ev);
-
-	/* Retrieve samdb url (local or external) */
-	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
-
-	if (!samdb_url) {
-		samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
-	} else {
-		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
-					      LDB_FLG_RECONNECT, samdb_url);
-	}
-
-	return samdb_ctx;
-}
 
 /**
    \details Initialize the EMSABP context and open connections to
@@ -107,7 +66,7 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 	/* Save a pointer to the loadparm context */
 	emsabp_ctx->lp_ctx = lp_ctx;
 
-	emsabp_ctx->samdb_ctx = samdb_init(lp_ctx);
+	emsabp_ctx->samdb_ctx = samdb_init(emsabp_ctx);
 	if (!emsabp_ctx->samdb_ctx) {
 		talloc_free(mem_ctx);
 		OC_DEBUG(0, "[nspi] Connection to \"sam.ldb\" failed");
@@ -173,10 +132,10 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_account_info(TALLOC_CTX *mem_ctx,
 	struct ldb_result	*res = NULL;
 	const char * const	recipient_attrs[] = { "*", NULL };
 
-	ret = ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
-			 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
-			 ldb_binary_encode_string(mem_ctx, username));
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
+			      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
+			      ldb_binary_encode_string(mem_ctx, username));
 	OPENCHANGE_RETVAL_IF((ret != LDB_SUCCESS || !res->count), MAPI_E_NOT_FOUND, NULL);
 
 	/* Check if more than one record was found */
@@ -755,8 +714,8 @@ _PUBLIC_ enum MAPISTATUS emsabp_fetch_attrs(TALLOC_CTX *mem_ctx, struct emsabp_c
 	ldb_dn = ldb_dn_new(mem_ctx, emsabp_ctx->samdb_ctx, dn);
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, NULL);
 
-	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn, LDB_SCOPE_BASE,
-			 recipient_attrs, NULL);
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn, LDB_SCOPE_BASE,
+			      recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, NULL);
 
 	/* Step 2. Retrieve property values and build aRow */
@@ -990,9 +949,9 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_HierarchyTable(TALLOC_CTX *mem_ctx, struct e
 	aRow_idx++;
 
 	/* Step 2. Retrieve the object pointed by addressBookRoots attribute: 'All Address Lists' */
-	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
-			 ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
-			 scope, recipient_attrs, "(addressBookRoots=*)");
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+			      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
+			      scope, recipient_attrs, "(addressBookRoots=*)");
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_CORRUPT_STORE, aRow);
 
 	addressBookRoots = ldb_msg_find_attr_as_string(res->msgs[0], "addressBookRoots", NULL);
@@ -1003,8 +962,8 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_HierarchyTable(TALLOC_CTX *mem_ctx, struct e
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, aRow);
 
 	scope = LDB_SCOPE_BASE;
-	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
-			 scope, recipient_attrs, NULL);
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
+			      scope, recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, aRow);
 
 	aRow = talloc_realloc(mem_ctx, aRow, struct PropertyRow_r, aRow_idx + 1);
@@ -1271,8 +1230,8 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_dn(struct emsabp_context *emsabp_ctx, con
 	ldb_dn = ldb_dn_new(emsabp_ctx->mem_ctx, emsabp_ctx->samdb_ctx, dn);
 	OPENCHANGE_RETVAL_IF(!ldb_dn_validate(ldb_dn), MAPI_E_CORRUPT_STORE, NULL);
 
-	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
-			 LDB_SCOPE_BASE, recipient_attrs, NULL);
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res, ldb_dn,
+			      LDB_SCOPE_BASE, recipient_attrs, NULL);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count || res->count != 1, MAPI_E_CORRUPT_STORE, NULL);
 
 	*ldb_res = res->msgs[0];
@@ -1308,17 +1267,17 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_legacyExchangeDN(struct emsabp_context *e
 	OPENCHANGE_RETVAL_IF(!pbUseConfPartition, MAPI_E_INVALID_PARAMETER, NULL);
 
 	*pbUseConfPartition = true;
-	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
-			 ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
+	ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+			      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
+			      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
+			      ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
 		*pbUseConfPartition = false;
-		ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
-				 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
-				 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-				 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
+		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
+				      ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
+				      LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
+				      ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 	}
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, NULL);
 
@@ -1353,9 +1312,9 @@ _PUBLIC_ enum MAPISTATUS emsabp_ab_fetch_filter(TALLOC_CTX *mem_ctx,
 
 	if (!ContainerID) {
 		/* if GAL is requested */
-		ret = ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
-				 ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
-				 LDB_SCOPE_SUBTREE, recipient_attrs, "(globalAddressList=*)");
+		ret = safe_ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
+				      ldb_get_config_basedn(emsabp_ctx->samdb_ctx),
+				      LDB_SCOPE_SUBTREE, recipient_attrs, "(globalAddressList=*)");
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_CORRUPT_STORE, NULL);
 
 		/* We could have more than one GAL, but all of them are equal so

--- a/mapiproxy/util/samdb.c
+++ b/mapiproxy/util/samdb.c
@@ -138,7 +138,7 @@ struct ldb_context *samdb_init(TALLOC_CTX *mem_ctx)
 		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
 					      LDB_FLG_RECONNECT, samdb_url);
 
-		samdb_ctx->modules->private_data->ldap->timeout = 10;
+		if (samdb_ctx) samdb_ctx->modules->private_data->ldap->timeout = 10;
 	}
 
 	return samdb_ctx;
@@ -171,9 +171,11 @@ int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
 	}
 
 	while (tries < 3) {
-		ret = ldb_search(ldb, mem_ctx, result, base, scope, attrs, formatted);
-
-		if (ret == LDB_SUCCESS) break;
+		if (ldb)
+		{
+			ret = ldb_search(ldb, mem_ctx, result, base, scope, attrs, formatted);
+			if (ret == LDB_SUCCESS) break;
+		}
 
 		OC_DEBUG(3, "sam db connection lost, reconnecting...");
 		ldb = samdb_reconnect(ldb);

--- a/mapiproxy/util/samdb.c
+++ b/mapiproxy/util/samdb.c
@@ -1,0 +1,184 @@
+/*
+   SamDB util functions
+
+   OpenChange Project
+
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "samdb.h"
+
+#include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/libmapiproxy/fault_util.h"
+
+/* Expose samdb_connect prototype */
+struct ldb_context *samdb_connect(TALLOC_CTX *, struct tevent_context *,
+				  struct loadparm_context *,
+				  struct auth_session_info *,
+				  unsigned int);
+
+struct ldb_context *samdb_connect_url(TALLOC_CTX *, struct tevent_context *,
+				      struct loadparm_context *,
+				      struct auth_session_info *,
+				      unsigned int,
+				      const char *);
+void tevent_loop_allow_nesting(struct tevent_context *);
+struct loadparm_context;
+
+/*
+  Private struct declarations to assign timeout when samdb_context is a
+  ldap connection (these struct are either private or not published on samba
+  package, libcli/ldap/ldpa_client.h).
+*/
+struct ldb_context {
+	struct ldb_module *modules;
+};
+
+struct ldb_module {
+	struct ldb_module *prev, *next;
+	struct ldb_context *ldb;
+	struct ildb_private *private_data;
+};
+
+struct ildb_private {
+	struct ldap_connection *ldap;
+};
+
+struct ldap_connection {
+	struct {
+		struct tstream_context *raw;
+		struct tstream_context *tls;
+		struct tstream_context *sasl;
+		struct tstream_context *active;
+
+		struct tevent_queue *send_queue;
+		struct tevent_req *recv_subreq;
+	} sockets;
+
+	struct loadparm_context *lp_ctx;
+
+	char *host;
+	uint16_t port;
+	bool ldaps;
+
+	const char *auth_dn;
+	const char *simple_pw;
+
+	struct {
+		char *url;
+		int max_retries;
+		int retries;
+		time_t previous;
+	} reconnect;
+
+	struct {
+		enum { LDAP_BIND_SIMPLE, LDAP_BIND_SASL } type;
+		void *creds;
+	} bind;
+
+	/* next message id to assign */
+	unsigned next_messageid;
+
+	/* Outstanding LDAP requests that have not yet been replied to */
+	struct ldap_request *pending;
+
+	/* Let's support SASL */
+	struct gensec_security *gensec;
+
+	/* the default timeout for messages */
+	int timeout;
+};
+/* End of private declaration to assign timeout to ldap connection */
+
+
+/* Loadparm context */
+static struct loadparm_context *lp_ctx = NULL;
+
+
+/**
+   \details Initialize ldb_context to samdb, creates one for all emsmdbp
+   contexts
+
+   \param lp_ctx pointer to the loadparm context
+ */
+struct ldb_context *samdb_init(TALLOC_CTX *mem_ctx)
+{
+	struct tevent_context		*ev;
+	const char			*samdb_url;
+	static struct ldb_context	*samdb_ctx;
+
+	if (!lp_ctx) lp_ctx = loadparm_init_global(true);
+
+	ev = tevent_context_init(mem_ctx);
+	if (!ev) {
+		return NULL;
+	}
+	tevent_loop_allow_nesting(ev);
+
+	/* Retrieve samdb url (local or external) */
+	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
+
+	OC_DEBUG(5, "Connecting to sam db");
+	if (!samdb_url) {
+		samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+	} else {
+		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
+					      LDB_FLG_RECONNECT, samdb_url);
+
+		samdb_ctx->modules->private_data->ldap->timeout = 10;
+	}
+
+	return samdb_ctx;
+}
+
+
+struct ldb_context *samdb_reconnect(struct ldb_context *samdb_ctx)
+{
+	TALLOC_CTX *mem_ctx = talloc_parent(samdb_ctx);
+	talloc_free(samdb_ctx);
+	return samdb_init(mem_ctx);
+}
+
+int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
+		    struct ldb_result **result, struct ldb_dn *base,
+		    enum ldb_scope scope, const char * const *attrs,
+		    const char *exp_fmt, ...)
+{
+	va_list ap;
+	int tries = 0;
+	int ret;
+	char *formatted = NULL;
+
+	if (exp_fmt) {
+		va_start(ap, exp_fmt);
+		formatted = talloc_vasprintf(mem_ctx, exp_fmt, ap);
+		va_end(ap);
+
+		if (!formatted) return LDB_ERR_OPERATIONS_ERROR;
+	}
+
+	while (tries < 3) {
+		ret = ldb_search(ldb, mem_ctx, result, base, scope, attrs, formatted);
+
+		if (ret == LDB_SUCCESS) break;
+
+		OC_DEBUG(3, "sam db connection lost, reconnecting...");
+		ldb = samdb_reconnect(ldb);
+		tries++;
+	}
+
+	return ret;
+}

--- a/mapiproxy/util/samdb.h
+++ b/mapiproxy/util/samdb.h
@@ -1,0 +1,47 @@
+/*
+   SamDB util functions
+
+   OpenChange Project
+
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __OC_SAMDB_H__
+#define __OC_SAMDB_H__
+
+#ifdef PRINTF_ATTRIBUTE
+#undef PRINTF_ATTRIBUTE
+#endif
+#define PRINTF_ATTRIBUTE(a1, a2)
+
+#include <tevent.h>
+#include <talloc.h>
+#include "libmapi/libmapi.h"
+#include <param.h>
+#include <ldb.h>
+
+struct ldb_context *samdb_init(TALLOC_CTX *mem_ctx);
+struct ldb_context *samdb_reconnect(struct ldb_context *samdb_ctx);
+
+#undef PRINTF_ATTRIBUTE
+#define PRINTF_ATTRIBUTE(a1, a2) __attribute__ ((format (__printf__, a1, a2)))
+
+int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
+		    struct ldb_result **result, struct ldb_dn *base,
+		    enum ldb_scope scope, const char * const *attrs,
+		    const char *exp_fmt, ...) PRINTF_ATTRIBUTE(7,8);
+
+#endif /* __OC_SAMDB_H__ */

--- a/mapiproxy/util/samdb.h
+++ b/mapiproxy/util/samdb.h
@@ -29,19 +29,16 @@
 
 #include <tevent.h>
 #include <talloc.h>
-#include "libmapi/libmapi.h"
 #include <param.h>
 #include <ldb.h>
+
+#include "libmapi/libmapi.h"
+#include "mapiproxy/libmapiproxy/libmapiproxy.h"
 
 struct ldb_context *samdb_init(TALLOC_CTX *mem_ctx);
 struct ldb_context *samdb_reconnect(struct ldb_context *samdb_ctx);
 
 #undef PRINTF_ATTRIBUTE
 #define PRINTF_ATTRIBUTE(a1, a2) __attribute__ ((format (__printf__, a1, a2)))
-
-int safe_ldb_search(struct ldb_context *ldb, TALLOC_CTX *mem_ctx,
-		    struct ldb_result **result, struct ldb_dn *base,
-		    enum ldb_scope scope, const char * const *attrs,
-		    const char *exp_fmt, ...) PRINTF_ATTRIBUTE(7,8);
 
 #endif /* __OC_SAMDB_H__ */


### PR DESCRIPTION
Samba 4.3 introduced a new behavior, ldap reconnection is not working in
ldb.

A reconnect procedure is added to avoid errors when LDAP connection
is lost. `SAFE_LDB_SEARCH` macro takes charge of checking results and
 trying to reconnect on error.


This may be a temporary workaround while we work on samba upstream
