### PR TITLE
Do not fail receiving an empty idset on SyncUploadStateStreamEnd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [Unreleased]
 
+### Fixes
+* Do not fail receiving an empty idset on SyncUploadStateStreamEnd
+
 ### Improvements
 * Give support to Autodiscover requests done by MS Remote Connectivity Analyzer
 

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2957,10 +2957,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 	synccontext = synccontext_object->object.synccontext;
 	parsed_idset = IDSET_parse(synccontext, synccontext->state_stream.buffer, false);
 
-	retval = IDSET_check_ranges(parsed_idset);
-	if (retval != MAPI_E_SUCCESS) {
-		mapi_repl->error_code = retval;
-		goto reset;
+	if (parsed_idset) {
+		retval = IDSET_check_ranges(parsed_idset);
+		if (retval != MAPI_E_SUCCESS) {
+			mapi_repl->error_code = retval;
+			goto reset;
+		}
 	}
 
 	switch (synccontext->state_property) {


### PR DESCRIPTION
This is a regression introduced by 4ede2afd.

This makes OXCFXICS testsuite pass again.