### PR TITLE
Notify missing --profile when using --create in mapiprofile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Do not fail receiving an empty idset on SyncUploadStateStreamEnd
 
 ### Improvements
+* Notify missing --profile when using --create in mapiprofile tool
 * Give support to Autodiscover requests done by MS Remote Connectivity Analyzer
 
 

--- a/utils/mapiprofile.c
+++ b/utils/mapiprofile.c
@@ -718,6 +718,10 @@ int main(int argc, const char *argv[])
 					 getenv("HOME"));
 	}
 
+	if (create && (profname == false)) {
+		show_help(pc, "profile");
+	}
+
 	if ((list == false) && (getfqdn == false) && (newdb == false) && (listlangs == false)
 	    && (getdflt == false) && (dump == false) && (rename == NULL) && 
 	    (!attribute) && (!profname || !profdb)) {


### PR DESCRIPTION
It took me a gdb session to realise that...