### PR TITLE
NSPI: Manage NULL as query values in ResolveNames ROPs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The descriptions should be useful and understandable for end users of OpenChange.
 Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
 
+## [unreleased] - XXXX-YY-ZZ
+
+### Improvements
+* Manage NULL as query values in resolving names in Global Address List
+
+
 ## [2.4-zentyal15] - 2015-11-26
 
 ### Fixes

--- a/libmapi/IABContainer.c
+++ b/libmapi/IABContainer.c
@@ -73,22 +73,29 @@ _PUBLIC_ enum MAPISTATUS ResolveNames(struct mapi_session *session,
 	TALLOC_CTX		*mem_ctx;
 	struct nspi_context	*nspi;
 	enum MAPISTATUS		retval;
+	uint32_t		usernames_count;
 
 	/* Sanity Checks */
 	OPENCHANGE_RETVAL_IF(!session, MAPI_E_SESSION_LIMIT, NULL);
 	OPENCHANGE_RETVAL_IF(!session->nspi, MAPI_E_SESSION_LIMIT, NULL);
 	OPENCHANGE_RETVAL_IF(!session->nspi->ctx, MAPI_E_SESSION_LIMIT, NULL);
+	OPENCHANGE_RETVAL_IF(!usernames, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!rowset, MAPI_E_INVALID_PARAMETER, NULL);
+
+	for (usernames_count = 0; usernames[usernames_count]; usernames_count++);
+	OPENCHANGE_RETVAL_IF(!usernames_count, MAPI_E_INVALID_PARAMETER, NULL);
 
 	nspi = (struct nspi_context *)session->nspi->ctx;
 	mem_ctx = talloc_named(session, 0, "ResolveNames");
 
 	switch (flags) {
 	case MAPI_UNICODE:
-		retval = nspi_ResolveNamesW(nspi, mem_ctx, usernames, props, &rowset, &flaglist);
+		retval = nspi_ResolveNamesW(nspi, mem_ctx, usernames, usernames_count,
+					    props, &rowset, &flaglist);
 		break;
 	default:
-		retval = nspi_ResolveNames(nspi, mem_ctx, usernames, props, &rowset, &flaglist);
+		retval = nspi_ResolveNames(nspi, mem_ctx, usernames, usernames_count,
+					   props, &rowset, &flaglist);
 		break;
 	}
 

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -105,8 +105,8 @@ enum MAPISTATUS		nspi_ModLinkAtt(struct nspi_context *, bool, uint32_t, uint32_t
 enum MAPISTATUS		nspi_QueryColumns(struct nspi_context *, TALLOC_CTX *, bool, struct SPropTagArray **);
 enum MAPISTATUS		nspi_GetNamesFromIDs(struct nspi_context *, TALLOC_CTX *, struct FlatUID_r *, struct SPropTagArray *, struct SPropTagArray **, struct PropertyNameSet_r **);
 enum MAPISTATUS		nspi_GetIDsFromNames(struct nspi_context *, TALLOC_CTX *, bool, uint32_t, struct PropertyName_r *, struct SPropTagArray **);
-enum MAPISTATUS		nspi_ResolveNames(struct nspi_context *, TALLOC_CTX *, const char **, struct SPropTagArray *, struct PropertyRowSet_r ***, struct PropertyTagArray_r ***);
-enum MAPISTATUS		nspi_ResolveNamesW(struct nspi_context *, TALLOC_CTX *, const char **, struct SPropTagArray *, struct PropertyRowSet_r ***, struct PropertyTagArray_r ***);
+enum MAPISTATUS		nspi_ResolveNames(struct nspi_context *, TALLOC_CTX *, const char **, uint32_t, struct SPropTagArray *, struct PropertyRowSet_r ***, struct PropertyTagArray_r ***);
+enum MAPISTATUS		nspi_ResolveNamesW(struct nspi_context *, TALLOC_CTX *, const char **, uint32_t, struct SPropTagArray *, struct PropertyRowSet_r ***, struct PropertyTagArray_r ***);
 void			nspi_dump_STAT(const char *, struct STAT *);
 
 /* The following public definitions come from libmapi/emsmdb.c */

--- a/libmapi/nspi.c
+++ b/libmapi/nspi.c
@@ -1086,6 +1086,7 @@ _PUBLIC_ enum MAPISTATUS nspi_GetIDsFromNames(struct nspi_context *nspi_ctx,
    \param mem_ctx pointer to the memory context
    \param usernames pointer on pointer to the list of values we want
    to perform ANR on
+   \param usernames_count the number of values within usernames list
    \param pPropTags pointer on the property tags list we want for each
    row returned
    \param pppRows pointer on pointer on pointer to the rows returned
@@ -1097,7 +1098,8 @@ _PUBLIC_ enum MAPISTATUS nspi_GetIDsFromNames(struct nspi_context *nspi_ctx,
  */
 _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx, 
 					   TALLOC_CTX *mem_ctx,
-					   const char **usernames, 
+					   const char **usernames,
+					   uint32_t usernames_count,
 					   struct SPropTagArray *pPropTags, 
 					   struct PropertyRowSet_r ***pppRows,
 					   struct PropertyTagArray_r ***pppMIds)
@@ -1106,7 +1108,6 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
 	struct StringsArray_r	*paStr;
 	NTSTATUS		status;
 	enum MAPISTATUS		retval;
-	uint32_t		count;
 
 	/* Sanity checks */
 	OPENCHANGE_RETVAL_IF(!nspi_ctx, MAPI_E_NOT_INITIALIZED, NULL);
@@ -1114,12 +1115,10 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
 	OPENCHANGE_RETVAL_IF(!nspi_ctx->rpc_connection->binding_handle, MAPI_E_NOT_INITIALIZED, NULL);
 	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!usernames, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!usernames_count, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!pPropTags, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!pppRows, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!pppMIds, MAPI_E_INVALID_PARAMETER, NULL);
-
-	for (count = 0; usernames[count]; count++);
-	OPENCHANGE_RETVAL_IF(!count, MAPI_E_INVALID_PARAMETER, NULL);
 
 	r.in.handle = &nspi_ctx->handle;
 
@@ -1128,7 +1127,7 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
 	r.in.pPropTags = pPropTags;
 	
 	paStr = talloc(mem_ctx, struct StringsArray_r);
-	paStr->Count = count;
+	paStr->Count = usernames_count;
 	paStr->Strings = (uint8_t **) usernames;
 	r.in.paStr = paStr;
 
@@ -1152,6 +1151,7 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
    \param mem_ctx pointer to the memory context
    \param usernames pointer on pointer to the list of values we want
    to perform ANR on
+   \param usernames_count the number of values within usernames list
    \param pPropTags pointer on the property tags list we want for each
    row returned
    \param pppRows pointer on pointer on pointer to the rows returned
@@ -1164,6 +1164,7 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNames(struct nspi_context *nspi_ctx,
 _PUBLIC_ enum MAPISTATUS nspi_ResolveNamesW(struct nspi_context *nspi_ctx, 
 					    TALLOC_CTX *mem_ctx,
 					    const char **usernames, 
+					    uint32_t usernames_count,
 					    struct SPropTagArray *pPropTags, 
 					    struct PropertyRowSet_r ***pppRows,
 					    struct PropertyTagArray_r ***pppMIds)
@@ -1172,16 +1173,13 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNamesW(struct nspi_context *nspi_ctx,
 	struct StringsArrayW_r		*paWStr;
 	NTSTATUS			status;
 	enum MAPISTATUS			retval;
-	uint32_t			count;
 
 	OPENCHANGE_RETVAL_IF(!nspi_ctx, MAPI_E_NOT_INITIALIZED, NULL);
 	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!usernames, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!usernames_count, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!pppRows, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!pppMIds, MAPI_E_INVALID_PARAMETER, NULL);
-
-	for (count = 0; usernames[count]; count++);
-	OPENCHANGE_RETVAL_IF(!count, MAPI_E_INVALID_PARAMETER, NULL);
 
 	r.in.handle = &nspi_ctx->handle;
 
@@ -1190,7 +1188,7 @@ _PUBLIC_ enum MAPISTATUS nspi_ResolveNamesW(struct nspi_context *nspi_ctx,
 	r.in.pPropTags = pPropTags;
 
 	paWStr = talloc(mem_ctx, struct StringsArrayW_r);
-	paWStr->Count = count;
+	paWStr->Count = usernames_count;
 	paWStr->Strings = usernames;
 	r.in.paWStr = paWStr;
 

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -1363,6 +1363,11 @@ static void dcesrv_do_NspiResolveNamesW(struct dcesrv_call_state *dce_call,
 		struct ldb_result	*ldb_res;
 		char			*filter;
 		int			j;
+		if (!paWStr->Strings[i]) {
+			/* Section 3.1.4.7 indicates as ANR of NULL with MID_UNRESOLVED */
+			pMIds->aulPropTag[i] = MAPI_UNRESOLVED;
+			continue;
+		}
 
 		filter = talloc_strdup(mem_ctx, "");
 		if (!filter) {

--- a/utils/mapitest/modules/module_nspi.c
+++ b/utils/mapitest/modules/module_nspi.c
@@ -933,6 +933,7 @@ _PUBLIC_ bool mapitest_nspi_GetIDsFromNames(struct mapitest *mt)
  */
 _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 {
+	bool				ret = true;
 	int				i;
 	enum MAPISTATUS			retval;
 	struct SPropTagArray		*SPropTagArray = NULL;
@@ -970,16 +971,17 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 	retval = ResolveNames(mt->session, (const char **)username, SPropTagArray, &RowSet, &flaglist, 0);
 	mapitest_print_retval_clean(mt, "NspiResolveNames - existing", retval);
 	if (retval != MAPI_E_SUCCESS) {
-		MAPIFreeBuffer(SPropTagArray);
-		return false;
+		ret = false;
+		goto cleanup;
 	}
-	if ( ! flaglist) {
+	if (!flaglist) {
 		mapitest_print(mt, "\tNULL flaglist, which wasn't expected\n");
-		MAPIFreeBuffer(SPropTagArray);
-		return false;
+		ret = false;
+		goto cleanup;
 	}
 	if (flaglist->aulPropTag[0] != MAPI_RESOLVED) {
 		mapitest_print(mt, "Expected 2 (MAPI_RESOLVED), but NspiResolveNames returned: %i\n", flaglist->aulPropTag[0]);
+		ret = false;
 	} else {
 		mapitest_print(mt, "\tGot expected resolution flag\n");
 	}
@@ -991,14 +993,15 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 	mapitest_print_retval_clean(mt, "NspiResolveNamesW - existing", retval);
 	if (flaglist->aulPropTag[0] != MAPI_RESOLVED) {
 		mapitest_print(mt, "Expected 2 (MAPI_RESOLVED), but NspiResolveNamesW returned: %i\n", flaglist->aulPropTag[0]);
+		ret = false;
 	} else {
 		mapitest_print(mt, "\tGot expected resolution flag\n");
 	}
 	talloc_free(flaglist);
 	talloc_free(RowSet);
 	if (retval != MAPI_E_SUCCESS) {
-		MAPIFreeBuffer(SPropTagArray);
-		return false;
+		ret = false;
+		goto cleanup;
 	}
 
 	/* Test with non-existant username */
@@ -1007,14 +1010,15 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 	mapitest_print_retval_clean(mt, "NspiResolveNames - non existant user name", retval);
 	if (flaglist->aulPropTag[0] != MAPI_UNRESOLVED) {
 		mapitest_print(mt, "Expected 0 (MAPI_UNRESOLVED), but NspiResolveNames returned: %i\n", flaglist->aulPropTag[0]);
+		ret = false;
 	} else {
 		mapitest_print(mt, "\tGot expected resolution flag\n");
 	}
 	talloc_free(flaglist);
 	talloc_free(RowSet);
 	if (retval != MAPI_E_SUCCESS) {
-		MAPIFreeBuffer(SPropTagArray);
-		return false;
+		ret = false;
+		goto cleanup;
 	}
 
 	/* NspiResolveNamesW (0x14) */
@@ -1022,14 +1026,15 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 	mapitest_print_retval_clean(mt, "NspiResolveNamesW - non existant user name", retval);
 	if (flaglist->aulPropTag[0] != MAPI_UNRESOLVED) {
 		mapitest_print(mt, "Expected 0 (MAPI_UNRESOLVED), but NspiResolveNamesW returned: %i\n", flaglist->aulPropTag[0]);
+		ret = false;
 	} else {
 		mapitest_print(mt, "\tGot expected resolution flag\n");
 	}
 	talloc_free(flaglist);
 	talloc_free(RowSet);
 	if (retval != MAPI_E_SUCCESS) {
-		MAPIFreeBuffer(SPropTagArray);
-		return false;
+		ret = false;
+		goto cleanup;
 	}
 
 	/* Test with NULL for paWStr */
@@ -1046,8 +1051,8 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 			mapitest_print(mt, "Expected 0 (MAPI_UNRESOLVED), but NspiResolveNames returned: %i\n", flaglist->aulPropTag[i]);
 			talloc_free(flaglist);
 			talloc_free(RowSet);
-			MAPIFreeBuffer(SPropTagArray);
-			return false;
+			ret = false;
+			goto cleanup;
 		}
 	}
 
@@ -1062,15 +1067,16 @@ _PUBLIC_ bool mapitest_nspi_ResolveNames(struct mapitest *mt)
 			mapitest_print(mt, "Expected 0 (MAPI_UNRESOLVED), but NspiResolveNamesW returned: %i\n", flaglist->aulPropTag[i]);
 			talloc_free(flaglist);
 			talloc_free(RowSet);
-			MAPIFreeBuffer(SPropTagArray);
-			return false;
+			ret = false;
+			goto cleanup;
 		}
 	}
 	talloc_free(flaglist);
 	talloc_free(RowSet);
 
+cleanup:
 	MAPIFreeBuffer(SPropTagArray);
-	return true;
+	return ret;
 }
 
 /**


### PR DESCRIPTION
Write a mapitest to make sure it is working.

The bug comes from a bug in an Outlook client request which derives from a bug in Contacts from OpenChange server side... :dango: 