### PR TITLE
oxcfxics: Perform CN restrictions on downloading changes to client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ### Fixes
 * Do not crash if we receive OAuth2 Auth Request in NTLM handler
 
+### Improvements
+* Perform Change Number restrictions to gather missing messages from
+  the current status of the client
+
 
 ## [2.4-zentyal16] - 2015-12-01
 


### PR DESCRIPTION
Using the given `CNSet_Seen` meta-property sent by the client we can ask
to the mapistore layer to retrieve only the missing messages.

We assume, likewise it was previously, the elements up to the first
globset range are not required as this element is the first CN seen by the client
upon first sync with empty state.