### PR TITLE
Fix crash caused by empty named_properties table

### DIFF
--- a/mapiproxy/libmapistore/backends/namedprops_mysql.c
+++ b/mapiproxy/libmapistore/backends/namedprops_mysql.c
@@ -116,7 +116,7 @@ static enum mapistore_error next_unused_id(struct namedprops_context *nprops,
 	MAPISTORE_RETVAL_IF(!res, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
 	row = mysql_fetch_row(res);
-	if (!row) {
+	if (!row || !row[0]) {
 		mysql_free_result(res);
 		mapistore_set_errno(MAPISTORE_ERR_DATABASE_OPS);
 		talloc_free(mem_ctx);


### PR DESCRIPTION
If the `named_properties` table is empty, the query

    SELECT max(mappedId) FROM <table>

returns `NULL`, causing a crash in `strtol()` later. Checking if `row[0]` is not `NULL` makes the code return `MAPISTORE_ERR_DATABASE_OPS` instead of crashing.