### PR TITLE
ntlm: Do not crash if we receive OAuth2 request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The descriptions should be useful and understandable for end users of OpenChange.
 Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
 
+## [unreleased] - YYYY-MM-DD
+
+### Fixes
+* Do not crash if we receive OAuth2 Auth Request in NTLM handler
+
+
 ## [2.4-zentyal16] - 2015-12-01
 
 ### Fixes

--- a/python/openchange/web/auth/NTLMAuthHandler.py
+++ b/python/openchange/web/auth/NTLMAuthHandler.py
@@ -645,7 +645,8 @@ class NTLMAuthHandler(object):
         else:
             cookie_name = "oc-ntlm-auth"
 
-        has_auth = "HTTP_AUTHORIZATION" in env
+        has_auth = ("HTTP_AUTHORIZATION" in env
+                    and not env['HTTP_AUTHORIZATION'].startswith('Bearer'))  # OAuth2
 
         return (work_dir, samba_host, cookie_name, has_auth)
 


### PR DESCRIPTION
'Bearer' is sent in HTTP_AUTHORIZATION to start the OAuth2 process.

The exception was:

```
      File "/usr/lib/python2.7/dist-packages/ocsmanager/config/middleware.py", line 77, in ntlm_env_setter
      return auth_handler(environ, start_response)
    File "/usr/lib/python2.7/dist-packages/openchange/web/auth/NTLMAuthHandler.py", line 583, in __call__
      ntlm_payload = auth[5:].decode("base64")
    File "/usr/lib/python2.7/encodings/base64_codec.py", line 42, in base64_decode
      output = base64.decodestring(input)
    File "/usr/lib/python2.7/base64.py", line 321, in decodestring
      return binascii.a2b_base64(s)
    Error: Incorrect padding
```