### PR TITLE
Fixes on submitting email messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ## [unreleased] - YYYY-MM-DD
 
 ### Fixes
+* Do not lose a mail sent when SMTP server is down and notify the client
 * Do not crash if we receive OAuth2 Auth Request in NTLM handler
 
 ### Improvements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
   the current status of the client
 
 
+### Improvements
+* Sharing messages are now managed in Online mode as well
+
 ## [2.4-zentyal16] - 2015-12-01
 
 ### Fixes

--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -1850,10 +1850,12 @@ _PUBLIC_ enum MAPISTATUS mapistore_error_to_mapi(enum mapistore_error mapistore_
 		mapi_err = MAPI_E_COLLISION;
 		break;
 	case MAPISTORE_ERR_INVALID_DATA:
-	case MAPISTORE_ERR_MSG_SEND:
 	case MAPISTORE_ERR_MSG_RCV:
 		mapi_err = MAPI_E_DISK_ERROR;
 		break;
+	case MAPISTORE_ERR_MSG_SEND:
+                mapi_err = ecRpcFailed;  /* MAPI_E_NETWORK_ERROR */
+                break;
 	case MAPISTORE_ERR_DENIED:
 		mapi_err = MAPI_E_NO_ACCESS;
 		break;


### PR DESCRIPTION
* Notify when mapistore fails to deliver by sending back MAPI_E_NETWORK_ERROR
    * This requires https://github.com/zentyal/sogo/pull/226 to work
    * Stop SMTP server to test it
* Uniform TransportSend and SubmitMessage ROPs
    * This makes missing sharing feature on SubmitMessage (used by Outlook Online mode) available