### PR TITLE
oxcstor: Deny the removal of special folders on provisioning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ## [unreleased] - 2016-0X-XX
 
 ### Fixes
+* Deny the removal of special folders on provisioning
 * Changed :days parameter in ocsmanager to a value which is RFC-compliant
 * Reconnect broken LDAP connections for some missing NSPI calls
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
@@ -362,9 +362,15 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 				current_entry = current_entry->next;
 			}
 			if (!exists) {
-				OC_DEBUG(5, "  removing entry '%s'\n", mapistore_url);
 				openchangedb_get_fid(emsmdbp_ctx->oc_ctx, mapistore_url, &found_fid);
-				openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, username, found_fid);
+				if (!oxosfld_is_special_folder(emsmdbp_ctx, found_fid)) {
+					OC_DEBUG(5, "Removing entry '%s'", mapistore_url);
+					openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, username, found_fid);
+				} else {
+					/* Do not delete a special folder */
+					OC_DEBUG(5, "Special folder %s (%"PRIx64") is missing but not deleting...",
+						 mapistore_url, found_fid);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a band-aid until we have synchronisation in oxcfxics for
deleted folders and notifying the client for that.