### PR TITLE
Optimize indexing warm up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ### Added
 * Dump PT_MV_LONG properties in FastTransfer Buffer NDR dump
 
+### Improvements
+* Indexing warm up much more efficient
+* Indexing keys store on memcached normally have username as prefix
+
+
 ## [2.4-zentyal20] - 2016-01-26
 
 ### Fixes

--- a/script/openchange_user_cleanup.py
+++ b/script/openchange_user_cleanup.py
@@ -63,6 +63,13 @@ class SambaOCHelper(object):
         c.execute("SELECT name FROM mailboxes")
         return sorted([row[0] for row in c.fetchall()])
 
+    def get_indexing_cache(self):
+        memcached_server = self.samba_lp.get('mapistore:indexing_cache')
+        if not memcached_server:
+            return "127.0.0.1:11211"
+        # This should has a format like: --SERVER=11.22.33.44:11211
+        return memcached_server.split('=')[1]
+
 
 class ImapCleaner(object):
     def __init__(self, dry_run=False, samba_helper=SambaOCHelper(),
@@ -208,9 +215,7 @@ class MemcachedCleaner(object):
         print " [Memcached] Deleted %d keys" % deleted_keys
 
     def _connect_to_memcached(self):
-        # FIXME read from openchange conf
-        host = "127.0.0.1:11211"
-        return memcache.Client([host])
+        return memcache.Client([self.samba_helper.get_indexing_cache()])
 
     def _get_all_keys(self, mc):
         keys = []

--- a/script/openchange_user_cleanup.py
+++ b/script/openchange_user_cleanup.py
@@ -185,11 +185,27 @@ class MemcachedCleaner(object):
             print " [Memcached] There are no keys to delete"
             return
 
-        print "WARNING: All data from memcached will be deleted"
-        if not self.dry_run:
-            for key in keys:
-                mc.delete(key)
-        print " [Memcached] Deleted %d keys" % len(keys)
+        deleted_keys = 0
+        keys_with_username = False
+        prefix = "indexing:" + username
+        for key in keys:
+            if key.startswith(prefix):
+                keys_with_username = True
+                deleted_keys += 1
+                if not self.dry_run:
+                    mc.delete(key)
+
+        if not keys_with_username:
+            # Old indexing keys didn't have username as prefix
+            # We didn't find any key with the username as prefix, so to be
+            # sure we remove username's keys we have to empty memcached
+            print "WARNING: All data from memcached will be deleted"
+            deleted_keys = len(keys)
+            if not self.dry_run:
+                for key in keys:
+                    mc.delete(key)
+
+        print " [Memcached] Deleted %d keys" % deleted_keys
 
     def _connect_to_memcached(self):
         # FIXME read from openchange conf


### PR DESCRIPTION
Stores when an user has been initialized, so the warm up process will be done only once.

Additional changes done:

* Indexing keys are now prefixed with username
* `openchange_user_cleanup` now works properly with memcached on different place than localhost (checks samba config to get memcached host)
