### PR TITLE
fxdump: Dump PT_MV_LONG properties in FastTransfer Buffer NDR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The descriptions should be useful and understandable for end users of OpenChange.
 Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
 
+## [unreleased] - 2016-XX-YY
+
+### Added
+* Dump PT_MV_LONG properties in FastTransfer Buffer NDR dump
+
 ## [2.4-zentyal20] - 2016-01-26
 
 ### Fixes

--- a/exchange.idl
+++ b/exchange.idl
@@ -309,7 +309,7 @@ System Attendant Private Interface
 		[size_is(cValues)] uint16	*lpi;
 	} ShortArray_r;
 
-	typedef struct {
+	typedef [public] struct {
 		[range(0,100000)] uint32	cValues;
 		[size_is(cValues)] uint32	*lpl;
 	} LongArray_r;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -4,6 +4,7 @@
   libndr mapi support
 
   Copyright (C) Julien Kerihuel 2015
+  Copyright (C) Enrique J. Hernandez 2015-2016
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -407,22 +408,23 @@ static int ndr_parse_namedproperty(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
                                struct ndr_pull *ndr_pull, uint32_t element)
 {
-	uint16_t                 PtypInteger16;
-	uint32_t                 PtypInteger32;
-	double                   PtypFloating64;
-	uint16_t                 PtypBoolean;
-	int64_t                  PtypInteger64;
-	struct FILETIME          PtypTime;
-	struct GUID              PtypGuid;
-	const char               *PtypString;
-	const char               *PtypString8;
-	struct Binary_r          PtypServerId;
-	struct SBinary           PtypBinary;
-	struct mapi_SLPSTRArrayW PtypMvUnicode;
-	const char               *_propValue;
-	char                     *propValue, *named_prop;
-	int	                 i, ret;
-	DATA_BLOB		 datablob;
+	uint16_t                  PtypInteger16;
+	uint32_t                  PtypInteger32;
+	double                    PtypFloating64;
+	uint16_t                  PtypBoolean;
+	int64_t                   PtypInteger64;
+	struct FILETIME           PtypTime;
+	struct GUID               PtypGuid;
+	const char                *PtypString;
+	const char                *PtypString8;
+	struct Binary_r           PtypServerId;
+	struct SBinary            PtypBinary;
+	struct LongArray_r	  PtypMvLong;
+	struct mapi_SLPSTRArrayW  PtypMvUnicode;
+	const char                *_propValue;
+	char                      *propValue, *named_prop;
+	int	                  i, ret;
+	DATA_BLOB		  datablob;
 
 	_propValue = get_proptag_name(element);
 	if (_propValue == NULL) {
@@ -527,6 +529,17 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 			}
 		}
 		ndr_print_mapi_SLPSTRArrayW(ndr, propValue, &PtypMvUnicode);
+		break;
+	case PT_MV_LONG:
+		NDR_CHECK_FT(ndr_pull_uint32(ndr_pull, NDR_SCALARS, &PtypMvLong.cValues));
+		PtypMvLong.lpl = talloc_zero_array(ndr_pull, uint32_t, PtypMvLong.cValues);
+		if (!PtypMvLong.lpl) {
+			return -1;
+		}
+		for (i = 0; i < PtypMvLong.cValues; i++) {
+			NDR_CHECK_FT(ndr_pull_uint32(ndr_pull, NDR_SCALARS, &PtypMvLong.lpl[i]));
+		}
+		ndr_print_LongArray_r(ndr, propValue, &PtypMvLong);
 		break;
 	default:
 	{


### PR DESCRIPTION
For example:

      0x91BC1003 (LID 0x00008028): struct LongArray_r
      cValues                  : 0x00000000 (0)
       lpl                      : *
       lpl: ARRAY(0)