### PR TITLE
Retry the samba connection attempt on ocsmanager startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Do not crash if we receive OAuth2 Auth Request in NTLM handler
 
 ### Improvements
+* Retry the samba connection attempt on ocsmanager startup
 * Sharing messages are now managed in Online mode as well
 * Perform Change Number restrictions to gather missing messages from
   the current status of the client

--- a/mapiproxy/services/ocsmanager/development.ini
+++ b/mapiproxy/services/ocsmanager/development.ini
@@ -18,6 +18,9 @@ auth = single
 debug = yes
 mapistore_root = /usr/local/samba/private
 mapistore_data = /usr/local/samba/private/mapistore
+# Uncomment to limit the connection attempts to samba server on startup
+# A zero value means unlimited. (Default: 0)
+# samba_retries = 3
 
 [auth:file]
 #file =

--- a/mapiproxy/services/ocsmanager/ocsmanager.ini
+++ b/mapiproxy/services/ocsmanager/ocsmanager.ini
@@ -16,6 +16,10 @@ error_email_from = paste@localhost
 auth = single
 mapistore_root = /var/lib/samba/private
 mapistore_data = /var/lib/samba/private/mapistore
+# Uncomment to limit the connection attempts to samba server on startup
+# A zero value means unlimited. (Default: 0)
+# samba_retries = 3
+
 debug = no
 
 [auth:file]

--- a/mapiproxy/services/ocsmanager/ocsmanager/lib/config.py
+++ b/mapiproxy/services/ocsmanager/ocsmanager/lib/config.py
@@ -110,6 +110,8 @@ class OCSConfig(object):
         self.__get_option('main', 'auth', 'auth', 'type')
         self.__get_option('main', 'mapistore_root')
         self.__get_option('main', 'mapistore_data')
+        self.__get_option('main', 'samba_retries', dflt=0)
+        self.d['main']['samba_retries'] = int(self.d['main']['samba_retries'])
         self.__get_option('main', 'debug')
         if self.d['main']['debug'] != "yes" and self.d['main']['debug'] != "no":
             log.error("%s: invalid debug value: %s. Must be set to yes or no", self.config, self.d['main']['debug'])


### PR DESCRIPTION
The retries occur until it connects but they could be limited
in the INI file.
The backoff time between attempts increases on each attempt, from 5 seconds
to a maximum of 60.