### PR TITLE
Avoid crash in RAWIDSET_push_eid

### DIFF
--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -1326,7 +1326,15 @@ _PUBLIC_ void RAWIDSET_push_guid_glob(struct rawidset *rawidset, const struct GU
 	struct rawidset		*last_glob_idset = NULL;
 	static struct GUID	*zero_guid = NULL;
 
-	if (!rawidset) return;
+	if (!rawidset) {
+		oc_log(OC_LOG_ERROR, "RAWIDSET is empty. Skipping.");
+		return;
+	}
+
+	if (rawidset->idbased) {
+		oc_log(OC_LOG_ERROR, "Attempting to push a GUID into an ID-based RAWIDSET. Skipping.");
+		return;
+	}
 
 	/* OC_DEBUG(0, "pushing %.16"PRIx64" into idset...", globcnt); */
 

--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -1287,7 +1287,15 @@ _PUBLIC_ void RAWIDSET_push_eid(struct rawidset *rawidset, uint64_t eid)
 	uint16_t eid_id;
 	uint64_t eid_globcnt;
 
-	if (!rawidset) return;
+	if (!rawidset) {
+		oc_log(OC_LOG_ERROR, "RAWIDSET is empty. Skipping.");
+		return;
+	}
+
+	if (!rawidset->idbased) {
+		oc_log(OC_LOG_ERROR, "Attempting to push an ID into a GUID-based RAWIDSET. Skipping.");
+		return;
+	}
 
 	eid_id = eid & 0xffff;
 	eid_globcnt = eid >> 16;


### PR DESCRIPTION
`RAWIDSET_find_by_ID` can return NULL without initialising
`last_glob_idset` when the rawidset isn't ID-based. Therefore, if we
pass an ID-based idset to this function it will try to access the `next`
attribute of a NULL pointer, causing a segmentation fault.