### PR TITLE
Sharing support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The descriptions should be useful and understandable for end users of OpenChange.
 Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
 
+## [unreleased] - 2016-XX-YY
+
+### Added
+
+* Give support to sharing calendars, contacts, tasks and
+  notes with different roles including Author, Editor or Folder Owner
+
 ## [2.4-zentyal22] - 2016-02-22
 
 ### Fixes

--- a/Makefile
+++ b/Makefile
@@ -808,6 +808,7 @@ mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION):	mapiproxy/libmapiproxy/dc
 							mapiproxy/libmapiproxy/backends/openchangedb_mysql.po	\
 							mapiproxy/libmapiproxy/backends/openchangedb_logger.po	\
 							mapiproxy/libmapiproxy/mapi_handles.po			\
+							mapiproxy/libmapiproxy/mapi_logon.po			\
 							mapiproxy/libmapiproxy/entryid.po			\
 							mapiproxy/libmapiproxy/modules.po			\
 							mapiproxy/libmapiproxy/fault_util.po			\
@@ -817,6 +818,7 @@ mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION):	mapiproxy/libmapiproxy/dc
 							mapiproxy/util/samdb.po					\
 							mapiproxy/util/schema_migration.po			\
 							mapiproxy/util/ccan/htable/htable.po			\
+							mapiproxy/util/ccan/hash/hash.po			\
 							libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
 	@$(CC) -o $@ $(DSOOPT) $(LDFLAGS) -Wl,-soname,libmapiproxy.$(SHLIBEXT).$(LIBMAPIPROXY_SO_VERSION) $^ -L. $(LIBS) $(TDB_LIBS) $(DL_LIBS) $(MYSQL_LIBS) $(PYTHON_LIBS) $(SAMBASERVER_LIBS) $(SAMDB_LIBS)
@@ -1448,6 +1450,7 @@ bin/openchange-testsuite: 	testsuite/testsuite.o					\
 				testsuite/libmapistore/mapistore_namedprops_tdb.c	\
 				testsuite/libmapistore/mapistore_indexing.c		\
 				testsuite/libmapistore/mapistore_notification.c		\
+				testsuite/libmapiproxy/logon_table.c			\
 				testsuite/libmapiproxy/openchangedb.c			\
 				testsuite/libmapiproxy/openchangedb_multitenancy.c	\
 				testsuite/mapiproxy/util/mysql.c			\

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -4,6 +4,9 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2008-2011
+   Copyright (C) Jesus Garcia 2013-2015
+   Copyright (C) Carlos Perez-Aradros 2015
+   Copyright (C) Enrique J. Hernandez 2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -137,6 +140,17 @@ struct mapi_handles_context {
 #define	MAPI_HANDLES_ROOT	"root"
 #define	MAPI_HANDLES_NULL	"null"
 
+/**
+   Logon map
+*/
+struct mapi_logon_context {
+        struct htable           *logon_table;
+};
+
+struct logon_table_value {
+        const char              *username;
+        uint8_t                 logon_id;
+};
 
 /**
    EMSABP server defines
@@ -291,6 +305,45 @@ enum MAPISTATUS mapi_handles_get_private_data(struct mapi_handles *, void **);
 enum MAPISTATUS mapi_handles_set_private_data(struct mapi_handles *, void *);
 enum MAPISTATUS mapi_handles_get_systemfolder(struct mapi_handles *, int *);
 enum MAPISTATUS mapi_handles_set_systemfolder(struct mapi_handles *, int);
+
+/* definitions from mapi_logon.c */
+
+/**
+   \details Initialise MAPI logon context
+
+   \param mem_ctx pointer to the memory context
+
+   \return Allocated MAPI logon context on success, otherwise NULL
+*/
+struct mapi_logon_context *mapi_logon_init(TALLOC_CTX *mem_ctx);
+/**
+   \details Release MAPI handles context
+
+   \param logon_ctx pointer to the MAPI logon context
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+*/
+enum MAPISTATUS mapi_logon_release(struct mapi_logon_context *logon_ctx);
+/**
+   \details Search for the logon_id in Logon Table
+
+   \param logon_ctx pointer to the MAPI logon context
+   \param logon_id the logon identifier
+   \param username pointer to the username associated with that logon_id if success
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+*/
+enum MAPISTATUS mapi_logon_search(struct mapi_logon_context *logon_ctx, uint8_t logon_id, const char **username_p);
+/**
+   \details Set the map between a logon_id and a username
+
+   \param logon_ctx pointer to the MAPI logon context
+   \param logon_id the logon id to set
+   \param username the associated username with that logon
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+*/
+enum MAPISTATUS mapi_logon_set(struct mapi_logon_context *logon_ctx, uint8_t logon_id, const char *username);
 
 /* definitions from entryid.c */
 enum MAPISTATUS entryid_set_AB_EntryID(TALLOC_CTX *, const char *, struct SBinary_short *);

--- a/mapiproxy/libmapiproxy/mapi_logon.c
+++ b/mapiproxy/libmapiproxy/mapi_logon.c
@@ -1,0 +1,164 @@
+/*
+   OpenChange Server implementation
+
+   MAPI logon map API implementation
+
+   Copyright (C) Enrique J. Hernandez 2016
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+   \file mapi_logon.c
+
+   \brief API for MAPI logon map as defined in [MS-OXCROPS] Section 3.1.4.2
+   inside a RPC session
+ */
+
+#include "libmapi/libmapi.h"
+#include "libmapi/libmapi_private.h"
+#include "libmapiproxy.h"
+#include "../util/ccan/htable/htable.h"
+#include "../util/ccan/hash/hash.h"
+
+/* Rehash function for ht table */
+static size_t _ht_rehash(const void* e, void* unused)
+{
+	return hash(&(((struct logon_table_value*)e)->logon_id), 1, 0);
+}
+
+/* Comparison function to get items from ht table */
+static bool _ht_cmp(const void* e, void *id)
+{
+	if (!id) {
+		return false;
+	}
+	return (((struct logon_table_value*) e)->logon_id == *(uint8_t*)id);
+}
+
+/**
+   \details Initialise MAPI logon context
+
+   \param mem_ctx pointer to the memory context
+
+   \return Allocated MAPI logon context on success, otherwise NULL
+ */
+_PUBLIC_ struct mapi_logon_context* mapi_logon_init(TALLOC_CTX *mem_ctx)
+{
+	struct mapi_logon_context *logon_ctx;
+
+	/* Step 1. Initialise the context */
+	logon_ctx = talloc_zero(mem_ctx, struct mapi_logon_context);
+	if (!logon_ctx) {
+		return NULL;
+	}
+
+	/* Step 2. Initialise the hash table */
+	logon_ctx->logon_table = talloc_zero(logon_ctx, struct htable);
+	if (!logon_ctx->logon_table) {
+		return NULL;
+	}
+	htable_init(logon_ctx->logon_table, _ht_rehash, NULL);
+
+	return logon_ctx;
+}
+
+/**
+   \details Release MAPI handles context
+
+   \param handles_ctx pointer to the MAPI handles context
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+ */
+_PUBLIC_ enum MAPISTATUS mapi_logon_release(struct mapi_logon_context *logon_ctx)
+{
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!logon_ctx, MAPI_E_NOT_INITIALIZED, NULL);
+
+	htable_clear(logon_ctx->logon_table);
+	talloc_free(logon_ctx);
+
+	return MAPI_E_SUCCESS;
+}
+
+/**
+   \details Search for the logon_id in Logon Table
+
+   \param logon_ctx pointer to the MAPI logon context
+   \param logon_id the logon identifier
+   \param username pointer to the username associated with that logon_id if success
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+ */
+_PUBLIC_ enum MAPISTATUS mapi_logon_search(struct mapi_logon_context *logon_ctx,
+					   uint8_t logon_id, const char **username_p)
+{
+	struct logon_table_value *entry;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!logon_ctx, MAPI_E_NOT_INITIALIZED, NULL);
+	OPENCHANGE_RETVAL_IF(!username_p, MAPI_E_INVALID_PARAMETER, NULL);
+
+	entry = (struct logon_table_value *)htable_get(logon_ctx->logon_table, hash(&logon_id, 1, 0), _ht_cmp, &logon_id);
+	if (entry) {
+		*username_p = entry->username;
+		return MAPI_E_SUCCESS;
+	}
+
+	return MAPI_E_NOT_FOUND;
+}
+
+/**
+   \details Set the map between a logon_id and a username
+
+   \param logon_ctx pointer to the MAPI logon context
+   \param logon_id the logon id to set
+   \param username the associated username with that logon
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+ */
+_PUBLIC_ enum MAPISTATUS mapi_logon_set(struct mapi_logon_context *logon_ctx,
+					uint8_t logon_id, const char *username)
+{
+	bool retval;
+	struct logon_table_value *new_entry, *old_entry;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!logon_ctx, MAPI_E_NOT_INITIALIZED, NULL);
+	OPENCHANGE_RETVAL_IF(!username, MAPI_E_INVALID_PARAMETER, NULL);
+
+	new_entry = talloc_zero(logon_ctx, struct logon_table_value);
+	OPENCHANGE_RETVAL_IF(!new_entry, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	new_entry->username = talloc_strdup(new_entry, username);
+	OPENCHANGE_RETVAL_IF(!new_entry->username, MAPI_E_NOT_ENOUGH_MEMORY, new_entry);
+
+	new_entry->logon_id = logon_id;
+
+	old_entry = (struct logon_table_value *)htable_get(logon_ctx->logon_table,
+							   hash(&logon_id, 1, 0), _ht_cmp,
+							   &logon_id);
+	if (old_entry) {
+		retval = htable_del(logon_ctx->logon_table, hash(&logon_id, 1, 0),
+				    old_entry);
+		if (retval) {
+			OC_DEBUG(5, "Reusing logon_id: %u", logon_id);
+		}
+	}
+
+	retval = htable_add(logon_ctx->logon_table, hash(&logon_id, 1, 0), new_entry);
+	OPENCHANGE_RETVAL_IF(retval == false, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	return MAPI_E_SUCCESS;
+}

--- a/mapiproxy/libmapistore/mapistore_backend.c
+++ b/mapiproxy/libmapistore/mapistore_backend.c
@@ -328,10 +328,15 @@ enum mapistore_error mapistore_backend_list_contexts(const char *username, struc
    \details Create backend context
 
    \param mem_ctx pointer to the memory context
+   \param conn_info the connection information available for this context
+                    (database connections, connected user, replica server info)
+   \param ictx indexing database connection object
    \param namespace the backend namespace
-   \param uri the backend parameters which can be passes inline
+   \param uri the backend URI
+   \param fid the folder identifier for this context
+   \param context_p pointer where the new context is created on success stored in mem_ctx
 
-   \return a valid backend_context pointer on success, otherwise NULL
+   \return MAPISTORE_SUCCESS on success, otherwise a mapistore error
  */
 enum mapistore_error mapistore_backend_create_context(TALLOC_CTX *mem_ctx, struct mapistore_connection_info *conn_info, struct indexing_context *ictx,
 						      const char *namespace, const char *uri, uint64_t fid, struct backend_context **context_p)

--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -150,8 +150,9 @@ _PUBLIC_ enum mapistore_error mapistore_release(struct mapistore_context *mstore
    \details Set connection info for current mapistore context
 
    \param mstore_ctx pointer to the mapistore context
-   \param oc_ctx pointer to the openchange ldb database
-   \param username pointer to the current username
+   \param sam_ctx pointer to the samba (LDAP) directory
+   \param oc_ctx pointer to the openchange database
+   \param username pointer to the current connected username
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error
  */
@@ -180,10 +181,15 @@ _PUBLIC_ enum mapistore_error mapistore_set_connection_info(struct mapistore_con
    \details Add a new connection context to mapistore
 
    \param mstore_ctx pointer to the mapistore context
+   \param owner the username of the owner of the resource from that URI
    \param uri the connection context URI
+   \param fid the folder identifier related with that URI
    \param context_id pointer to the context identifier the function returns
+   \param backend_object pointer to the recently created backend object
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error
+
+   \note it is responsability of the caller to free the returned data.
  */
 _PUBLIC_ enum mapistore_error mapistore_add_context(struct mapistore_context *mstore_ctx, const char *owner,
 						    const char *uri, uint64_t fid, uint32_t *context_id, void **backend_object)

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -1604,7 +1604,7 @@ static enum MAPISTATUS dcesrv_EcDoAsyncConnectEx(struct dcesrv_call_state *dce_c
 	retval = emsmdbp_get_external_email(emsmdbp_ctx, &email);
 	if (retval != MAPISTORE_SUCCESS) {
 		OC_DEBUG(1, "[EcDoAsyncConnectEx] Unable to find external email "
-			 "(for %s) to register session", emsmdbp_ctx->username);
+			 "(for %s) to register session", emsmdbp_ctx->auth_user);
 		r->out.async_handle->handle_type = 0;
 		r->out.async_handle->uuid = GUID_zero();
 		r->out.result = DCERPC_FAULT_CONTEXT_MISMATCH;

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -5,6 +5,7 @@
 
    Copyright (C) Julien Kerihuel 2009-2015
    Copyright (C) Carlos Pérez-Aradros Herce 2015
+   Copyright (C) Enrique J. Hernandez 2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -307,6 +308,18 @@ static struct mapi_response *EcDoRpc_process_transaction(TALLOC_CTX *mem_ctx,
 								  struct EcDoRpc_MAPI_REPL, idx + 2);
 		}
 
+		if (mapi_request->mapi_req[i].opnum != op_MAPI_Logon) {
+			retval = mapi_logon_search(emsmdbp_ctx->logon_ctx,
+						   mapi_request->mapi_req[i].logon_id,
+						   &emsmdbp_ctx->logon_user);
+			if (retval != MAPI_E_SUCCESS) {
+				emsmdbp_ctx->logon_user = NULL;
+				OC_DEBUG(1, "Logon_id: %x not found", mapi_request->mapi_req[i].logon_id);
+			} else {
+				OC_DEBUG(6, "Logon user: %s", emsmdbp_ctx->logon_user);
+			}
+		}
+
 		switch (mapi_request->mapi_req[i].opnum) {
 		case op_MAPI_Release: /* 0x01 */
 			retval = EcDoRpc_RopRelease(mem_ctx, emsmdbp_ctx,
@@ -319,7 +332,7 @@ static struct mapi_response *EcDoRpc_process_transaction(TALLOC_CTX *mem_ctx,
 						       &(mapi_response->mapi_repl[idx]),
 						       mapi_response->handles, &size);
 			break;
-		case op_MAPI_OpenMessage: /* 0x3 */
+		case op_MAPI_OpenMessage: /* 0x03 */
 			retval = EcDoRpc_RopOpenMessage(mem_ctx, emsmdbp_ctx,
 							&(mapi_request->mapi_req[i]),
 							&(mapi_response->mapi_repl[idx]),
@@ -367,7 +380,7 @@ static struct mapi_response *EcDoRpc_process_transaction(TALLOC_CTX *mem_ctx,
 							  &(mapi_response->mapi_repl[idx]),
 							  mapi_response->handles, &size);
 			break;
-		case op_MAPI_DeleteProps: /* 0xb */
+		case op_MAPI_DeleteProps: /* 0x0b */
 			retval = EcDoRpc_RopDeleteProperties(mem_ctx, emsmdbp_ctx,
 							     &(mapi_request->mapi_req[i]),
 							     &(mapi_response->mapi_repl[idx]),
@@ -392,7 +405,7 @@ static struct mapi_response *EcDoRpc_process_transaction(TALLOC_CTX *mem_ctx,
 							     mapi_response->handles, &size);
 			break;
 
-		/* op_MAPI_ReadRecipients: 0xf */
+		/* op_MAPI_ReadRecipients: 0x0f */
 		case op_MAPI_ReloadCachedInformation: /* 0x10 */
 			retval = EcDoRpc_RopReloadCachedInformation(mem_ctx, emsmdbp_ctx,
 								    &(mapi_request->mapi_req[i]),

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -5,6 +5,7 @@
 
    Copyright (C) Julien Kerihuel 2009-2010
    Copyright (C) Carlos Pérez-Aradros Herce 2015
+   Copyright (C) Enrique J. Hernandez 2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -49,6 +50,7 @@ struct emsmdbp_context {
 	char					*szUserDN;
 	char					*szDisplayName;
 	uint32_t				userLanguage;
+	const char				*logon_user;
 	char					*username;
 	char					*szDNPrefix;
 	struct loadparm_context			*lp_ctx;
@@ -59,6 +61,7 @@ struct emsmdbp_context {
 
 	TALLOC_CTX				*mem_ctx;
 	struct GUID				session_uuid;
+	struct mapi_logon_context		*logon_ctx;
 };
 
 struct emsmdbp_stream {

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -50,8 +50,8 @@ struct emsmdbp_context {
 	char					*szUserDN;
 	char					*szDisplayName;
 	uint32_t				userLanguage;
-	const char				*logon_user;
-	char					*username;
+	const char				*auth_user;  /* From EcDoConnect(|Ex) */
+	const char				*logon_user; /* From Logon ROP */
 	char					*szDNPrefix;
 	struct loadparm_context			*lp_ctx;
 	struct openchangedb_context		*oc_ctx;

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -276,8 +276,8 @@ _PUBLIC_ bool emsmdbp_verify_user(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Get a copy of the username for later use and setup missing conn_info components */
-	emsmdbp_ctx->username = talloc_strdup(emsmdbp_ctx, username);
-	openchangedb_get_MailboxReplica(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &emsmdbp_ctx->mstore_ctx->conn_info->repl_id, &emsmdbp_ctx->mstore_ctx->conn_info->replica_guid);
+	emsmdbp_ctx->auth_user = talloc_strdup(emsmdbp_ctx, username);
+	openchangedb_get_MailboxReplica(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, &emsmdbp_ctx->mstore_ctx->conn_info->repl_id, &emsmdbp_ctx->mstore_ctx->conn_info->replica_guid);
 
 	return true;
 }
@@ -687,10 +687,10 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_external_email(struct emsmdbp_context *emsm
 			      ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			      LDB_SCOPE_SUBTREE, attrs,
 			      "(&(objectClass=user)(sAMAccountName=%s))",
-			      ldb_binary_encode_string(emsmdbp_ctx, emsmdbp_ctx->username));
+			      ldb_binary_encode_string(emsmdbp_ctx, emsmdbp_ctx->auth_user));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
-		OC_DEBUG(5, "Couldn't find %s using ldb_search", emsmdbp_ctx->username);
+		OC_DEBUG(5, "Couldn't find %s using ldb_search", emsmdbp_ctx->auth_user);
 		return MAPI_E_NOT_FOUND;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -4,7 +4,7 @@
    EMSMDBP: EMSMDB Provider implementation
 
    Copyright (C) Julien Kerihuel 2009-2015
-   Copyright (C) Enrique J. Hernández 2015
+   Copyright (C) Enrique J. Hernández 2015-2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
@@ -71,7 +71,7 @@ static enum MAPISTATUS get_new_public_folder_id(struct emsmdbp_context *emsmdbp_
 	enum mapistore_error	ret;
 
 	if (openchangedb_is_public_folder_id(emsmdbp_ctx->oc_ctx, parent_fid)) {
-		retval = openchangedb_get_new_public_folderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid);
+		retval = openchangedb_get_new_public_folderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, fid);
 	} else {
 		ret = mapistore_indexing_get_new_folderID(emsmdbp_ctx->mstore_ctx, fid);
 		if (ret != MAPISTORE_SUCCESS) {
@@ -134,44 +134,44 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_mailbox_provision_public_freebusy(struct emsmdb
 		dn_user[i] = toupper(dn_user[i]);
 	}
 
-	retval = openchangedb_get_PublicFolderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, EMSMDBP_PF_FREEBUSY, &public_fb_fid);
+	retval = openchangedb_get_PublicFolderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, EMSMDBP_PF_FREEBUSY, &public_fb_fid);
 	if (retval != MAPI_E_SUCCESS) {
 		OC_DEBUG(5, "provisioning: freebusy root folder not found in OpenChange database.\n");
 		goto end;
 	}
 
-	retval = openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, public_fb_fid, dn_root, &group_fid);
+	retval = openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, public_fb_fid, dn_root, &group_fid);
 	if (retval != MAPI_E_SUCCESS) {
 		retval = get_new_public_folder_id(emsmdbp_ctx, public_fb_fid, &group_fid);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot get new public folder id\n");
 			goto end;
 		}
-		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &change_num);
+		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, &change_num);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot get new change number\n");
 			goto end;
 		}
-		openchangedb_create_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, public_fb_fid, group_fid, change_num, NULL, -1);
+		openchangedb_create_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, public_fb_fid, group_fid, change_num, NULL, -1);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot create new folder\n");
 			goto end;
 		}
 	}
 
-	retval = openchangedb_get_mid_by_subject(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, group_fid, dn_user, false, &fb_mid);
+	retval = openchangedb_get_mid_by_subject(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, group_fid, dn_user, false, &fb_mid);
 	if (retval != MAPI_E_SUCCESS) {
 		retval = get_new_public_folder_id(emsmdbp_ctx, group_fid, &fb_mid);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot get new public folder id\n");
 			goto end;
 		}
-		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &change_num);
+		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, &change_num);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot get new change number\n");
 			goto end;
 		}
-		retval = openchangedb_message_create(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fb_mid, group_fid, false, &message_object);
+		retval = openchangedb_message_create(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->auth_user, fb_mid, group_fid, false, &message_object);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(0, "Cannot create new message\n");
 			goto end;
@@ -791,7 +791,7 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 	/** create root/Freebusy Data folder + "LocalFreebusy" message (OXODLGT) */
 	/* FIXME: the problem here is that only the owner of a mailbox can create the delegation message and its container, meaning that when sharing an object, a delegate must at least login once to OpenChange before any one subscribes to his resources */
-	if (strcmp(emsmdbp_ctx->username, username) == 0) {
+	if (strcmp(emsmdbp_ctx->auth_user, username) == 0) {
 		struct mapi_SRestriction restriction;
 		uint8_t status;
 

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -477,7 +477,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 		/* Step 3. Turn CreateFolder parameters into MAPI property array */
 		parent_fid = parent_object->object.folder->folderID;
 		if (openchangedb_is_public_folder_id(emsmdbp_ctx->oc_ctx, parent_fid)) {
-			retval = openchangedb_get_new_public_folderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &fid);
+			retval = openchangedb_get_new_public_folderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, &fid);
 		} else {
 			retval = mapistore_error_to_mapi(mapistore_indexing_get_new_folderID(emsmdbp_ctx->mstore_ctx, &fid));
 		}
@@ -487,7 +487,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 			goto end;
 		}
 
-		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &cn);
+		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, &cn);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(4, "exchange_emsmdb: [OXCFOLD] Could not obtain a new folder cn\n");
 			mapi_repl->error_code = MAPI_E_NO_SUPPORT;

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -4,6 +4,7 @@
    EMSMDBP: EMSMDB Provider implementation
 
    Copyright (C) Julien Kerihuel 2009-2010
+   Copyright (C) Enrique J. Hernandez 2015-2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -86,6 +87,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenFolder(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	/* With OpenFolder, the parent object may NOT BE the direct parent folder of the folder */
 	mapi_handles_get_private_data(parent, &private_data);
         parent_object = private_data;
@@ -158,7 +165,6 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetHierarchyTable(TALLOC_CTX *mem_ctx,
 	mapi_repl->error_code = MAPI_E_SUCCESS;
 	mapi_repl->handle_idx = mapi_req->u.mapi_GetHierarchyTable.handle_idx;
 
-	/* GetHierarchyTable can only be called for mailbox/folder objects */
 	handle = handles[mapi_req->handle_idx];
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, handle, &parent);
 	if (retval) {
@@ -175,6 +181,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetHierarchyTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* GetHierarchyTable can only be called for mailbox/folder objects */
 	if ((parent_object->type != EMSMDBP_OBJECT_MAILBOX) &&
 	    (parent_object->type != EMSMDBP_OBJECT_FOLDER)) {
 		OC_DEBUG(5, "unsupported object type");
@@ -270,7 +283,6 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetContentsTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	/* GetContentsTable can only be called for folder objects */
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval != MAPI_E_SUCCESS) {
 		mapi_repl->error_code = retval;
@@ -285,6 +297,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetContentsTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* GetContentsTable can only be called for folder objects */
 	if (parent_object->type != EMSMDBP_OBJECT_FOLDER) {
 		mapi_repl->error_code = MAPI_E_INVALID_OBJECT;
 		goto end;
@@ -390,7 +409,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, handle, &parent);
 	OPENCHANGE_RETVAL_IF(retval, retval, NULL);
 
-	/* With CreateFolder, the parent object really IS the parent object */
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	mapi_handles_get_private_data(parent, &data);
 	parent_object = (struct emsmdbp_object *)data;
 	if (!parent_object) {
@@ -399,6 +423,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* With CreateFolder, the parent object really IS the parent object */
 	if (parent_object->type == EMSMDBP_OBJECT_MAILBOX) {
 		mapi_repl->error_code = MAPI_E_NO_SUPPORT;
 		goto end;
@@ -557,13 +582,19 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopDeleteFolder(TALLOC_CTX *mem_ctx,
 	if (!handle_object) {
 		OC_DEBUG(4, "exchange_emsmdb: [OXCFOLD] DeleteFolder null object\n");
 		mapi_repl->error_code = MAPI_E_NO_SUPPORT;
-		return MAPI_E_SUCCESS;
+                goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
 	}
 
 	if (handle_object->type != EMSMDBP_OBJECT_FOLDER) {
 		OC_DEBUG(4, "exchange_emsmdb: [OXCFOLD] DeleteFolder wrong object type: 0x%x\n", handle_object->type);
 		mapi_repl->error_code = MAPI_E_NO_SUPPORT;
-		return MAPI_E_SUCCESS;
+		goto end;
 	}
 
 	retval = MAPI_E_SUCCESS;
@@ -581,6 +612,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopDeleteFolder(TALLOC_CTX *mem_ctx,
 	}
 	mapi_repl->error_code = retval;
 
+end:
 	*size += libmapiserver_RopDeleteFolder_size(mapi_repl);
 
 	return MAPI_E_SUCCESS;
@@ -634,6 +666,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopDeleteMessages(TALLOC_CTX *mem_ctx,
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, parent_folder_handle, &parent_folder);
 	if (retval != MAPI_E_SUCCESS) {
 		mapi_repl->error_code = MAPI_E_NOT_FOUND;
+		goto delete_message_response;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto delete_message_response;
 	}
 
@@ -895,6 +933,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopEmptyFolder(TALLOC_CTX *mem_ctx,
 	/* Step 1. Retrieve folder handle */
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, handles[mapi_req->handle_idx], &folder);
 	OPENCHANGE_RETVAL_IF(retval, retval, NULL);
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	mapi_handles_get_private_data(folder, &private_data);
         folder_object = private_data;
 
@@ -921,6 +966,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopEmptyFolder(TALLOC_CTX *mem_ctx,
 		break;
 	}
 
+end:
 	*size += libmapiserver_RopEmptyFolder_size(mapi_repl);
 
 	/* reply filled in above */
@@ -963,12 +1009,18 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopMoveCopyMessages(TALLOC_CTX *mem_ctx,
 
 	mapi_repl->u.mapi_MoveCopyMessages.PartialCompletion = 0;
 
-	/* Get the destionation information */
+	/* Get the destination information */
 	handle = handles[mapi_req->u.mapi_MoveCopyMessages.handle_idx];
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, handle, &rec);
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1079,6 +1131,13 @@ enum MAPISTATUS EcDoRpc_RopMoveFolder(TALLOC_CTX *mem_ctx, struct emsmdbp_contex
 		mapi_repl->error_code = ecNullObject;
 		goto end;
 	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	mapi_handles_get_private_data(handle_object, &private_data);
         source_parent = private_data;
 	if (!source_parent || source_parent->type != EMSMDBP_OBJECT_FOLDER) {
@@ -1175,6 +1234,13 @@ enum MAPISTATUS EcDoRpc_RopCopyFolder(TALLOC_CTX *mem_ctx, struct emsmdbp_contex
 		mapi_repl->error_code = ecNullObject;
 		goto end;
 	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	mapi_handles_get_private_data(handle_object, &private_data);
         source_parent = private_data;
 	if (!source_parent || source_parent->type != EMSMDBP_OBJECT_FOLDER) {

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2541,7 +2541,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportHierarchyChange(TALLOC_CTX *mem_ct
 
 	retval = emsmdbp_object_open_folder_by_fid(NULL, emsmdbp_ctx, parent_folder, folderID, &folder_object);
 	if (retval != MAPI_E_SUCCESS) {
-		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, &cn);
+		retval = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, &cn);
 		if (retval) {
 			OC_DEBUG(5, "unable to obtain a change number\n");
 			folder_object = NULL;
@@ -3082,7 +3082,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		if (parsed_idset) {
 			parsed_idset->single = true;
 		}
-		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen");
+		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, parsed_idset, "cnset_seen");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
 			goto reset;
@@ -3094,7 +3094,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		if (parsed_idset) {
 			parsed_idset->single = true;
 		}
-		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen_fai");
+		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, parsed_idset, "cnset_seen_fai");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
 			goto reset;
@@ -3106,7 +3106,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		if (parsed_idset) {
 			parsed_idset->single = true;
 		}
-		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen_read");
+		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, parsed_idset, "cnset_seen_read");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
 			goto reset;
@@ -3859,7 +3859,7 @@ static enum MAPISTATUS oxcfxics_ndr_push_transfer_state(struct ndr_push *ndr, co
 	talloc_free(old_idset);
 	talloc_free(new_idset);
 
-	retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, synccontext->cnset_seen, "cnset_seen");
+	retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user, synccontext->cnset_seen, "cnset_seen");
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, mem_ctx);
 
 	ndr_push_uint32(ndr, NDR_SCALARS, MetaTagCnsetSeen);
@@ -3876,7 +3876,7 @@ static enum MAPISTATUS oxcfxics_ndr_push_transfer_state(struct ndr_push *ndr, co
 		talloc_free(old_idset);
 		talloc_free(new_idset);
 
-		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->logon_user,
 					      synccontext->cnset_seen_fai, "cnset_seen_fai");
 		OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, mem_ctx);
 

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -6,7 +6,7 @@
    Copyright (C) Wolfgang Sourdeau 2010-2012
    Copyright (C) Julien Kerihuel 2009-2015
    Copyright (C) Jesús García 2014
-   Copyright (C) Enrique J. Hernández 2015
+   Copyright (C) Enrique J. Hernández 2015-2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -471,7 +471,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFastTransferSourceCopyTo(TALLOC_CTX *mem_ctx
 		goto end;
 	}
 
-	/* Step 2. Check whether the parent object supports fetching properties */
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* Step 3. Check whether the parent object supports fetching properties */
 	mapi_handles_get_private_data(parent_object_handle, &data);
 	parent_object = (struct emsmdbp_object *) data;
 
@@ -1961,7 +1967,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFastTransferSourceGetBuffer(TALLOC_CTX *mem_
 		goto end;
 	}
 
-	/* Step 2. Check whether the parent object supports fetching properties */
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* Step 3. Check whether the parent object supports fetching properties */
 	mapi_handles_get_private_data(object_handle, &data);
 	object = (struct emsmdbp_object *) data;
 	if (!object) {
@@ -1978,7 +1990,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFastTransferSourceGetBuffer(TALLOC_CTX *mem_
 		request_buffer_size = request->MaximumBufferSize.MaximumBufferSize;
 	}
 
-	/* Step 3. Perform the read operation */
+	/* Step 4. Perform the read operation */
 	switch (object->type) {
 	case EMSMDBP_OBJECT_FTCONTEXT:
 		oxcfxics_fill_ftcontext_fasttransfer_response(response, request_buffer_size, mem_ctx, object->object.ftcontext, emsmdbp_ctx);
@@ -2062,6 +2074,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncConfigure(TALLOC_CTX *mem_ctx,
 	if (!folder_object || folder_object->type != EMSMDBP_OBJECT_FOLDER) {
 		OC_DEBUG(5, "  object not found or not a folder\n");
 		mapi_repl->error_code = MAPI_E_INVALID_OBJECT;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -2312,6 +2330,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportMessageChange(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	mapi_handles_get_private_data(synccontext_object_handle, &data);
 	synccontext_object = (struct emsmdbp_object *)data;
 	if (!synccontext_object || synccontext_object->type != EMSMDBP_OBJECT_SYNCCONTEXT) {
@@ -2459,6 +2483,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportHierarchyChange(TALLOC_CTX *mem_ct
 	if (!synccontext_object || synccontext_object->type != EMSMDBP_OBJECT_SYNCCONTEXT) {
 		OC_DEBUG(5, "  object not found or not a synccontext\n");
 		mapi_repl->error_code = MAPI_E_INVALID_OBJECT;
+		goto end;
+	}
+
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -2634,6 +2664,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	request = &mapi_req->u.mapi_SyncImportDeletes;
 
 	if (request->Flags & SyncImportDeletes_HardDelete) {
@@ -2804,6 +2840,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamBegin(TALLOC_CTX *mem_c
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	if (synccontext_object->object.synccontext->state_property != 0) {
 		OC_DEBUG(5, "  stream already in pending state\n");
 		mapi_repl->error_code = MAPI_E_NOT_INITIALIZED;
@@ -2871,6 +2913,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamContinue(TALLOC_CTX *me
 	if (retval) {
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", synccontext_handle, mapi_req->handle_idx);
 		mapi_repl->error_code = ecNullObject;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -2983,6 +3031,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 	if (retval) {
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", synccontext_handle, mapi_req->handle_idx);
 		mapi_repl->error_code = ecNullObject;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -3171,6 +3225,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportMessageMove(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	request = &mapi_req->u.mapi_SyncImportMessageMove;
 
 	/* FIXME: we consider the local replica to always have id 1. This is correct for now but might pose problems if the local replica handling changes. */
@@ -3299,6 +3359,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncOpenCollector(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_add(emsmdbp_ctx->handles_ctx, folder_handle, &synccontext_rec);
 
 	synccontext_object = emsmdbp_object_synccontext_init((TALLOC_CTX *)synccontext_rec, emsmdbp_ctx, folder_object);
@@ -3381,6 +3447,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetLocalReplicaIds(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	/* Step 2. Check whether the parent object supports fetching properties */
 	mapi_handles_get_private_data(object_handle, &data);
 	mailbox_object = (struct emsmdbp_object *) data;
@@ -3460,6 +3532,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportReadStateChanges(TALLOC_CTX *mem_c
 	if (retval) {
                 mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", synccontext_handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -3871,6 +3949,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncGetTransferState(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", synccontext_handle_id, mapi_req->handle_idx);
 		mapi_repl->error_code = ecNullObject;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -430,7 +430,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 	case false:
 		retval = openchangedb_message_create(emsmdbp_ctx->mstore_ctx, 
 						     emsmdbp_ctx->oc_ctx,
-						     emsmdbp_ctx->username,
+						     emsmdbp_ctx->logon_user,
 						     messageID, folderID,
 						     mapi_req->u.mapi_CreateMessage.AssociatedFlag,
 						     &message_object->backend_object);

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -4,6 +4,8 @@
    EMSMDBP: EMSMDB Provider implementation
 
    Copyright (C) Julien Kerihuel 2009-2014
+                 Wolfgang Wourdeau 2011
+                 Enrique J. Hernandez 2015-2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -390,9 +392,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	/* This should be handled differently here: temporary hack */
-	ret = mapistore_indexing_get_new_folderID(emsmdbp_ctx->mstore_ctx, &messageID);
-	if (ret) {
+	ret = mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx,
+							  emsmdbp_ctx->logon_user,
+							  &messageID);
+	if (ret != MAPISTORE_SUCCESS) {
+		OC_DEBUG(1, "Impossible to get new message id: %s",
+			 mapistore_errstr(ret));
 		mapi_repl->error_code = MAPI_E_NO_SUPPORT;
 		goto end;
 	}
@@ -1694,8 +1699,10 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenEmbeddedMessage(TALLOC_CTX *mem_ctx,
 	case true:
 		contextID = emsmdbp_get_contextID(attachment_object);
 		if (request->OpenModeFlags == MAPI_CREATE) {
-			ret = mapistore_indexing_get_new_folderID(emsmdbp_ctx->mstore_ctx, &messageID);
-			if (ret) {
+			ret = mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx, emsmdbp_ctx->logon_user, &messageID);
+			if (ret != MAPISTORE_SUCCESS) {
+				OC_DEBUG(1, "Impossible to get new message id: %s",
+					 mapistore_errstr(ret));
 				mapi_repl->error_code = MAPI_E_NO_SUPPORT;
 				goto end;
 			}

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -206,6 +206,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenMessage(TALLOC_CTX *mem_ctx,
 		return MAPI_E_SUCCESS;
 	}
 
+	/* Check we have the logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	/* OpenMessage can only be called for mailbox/folder objects */
 	if (!(context_object->type == EMSMDBP_OBJECT_MAILBOX || context_object->type == EMSMDBP_OBJECT_FOLDER)) {
 		mapi_repl->error_code = MAPI_E_INVALID_OBJECT;
@@ -357,13 +363,22 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
 		goto end;
 	}
-	/* With CreateMessage, the parent object may NOT BE the direct parent folder of the message */
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(context_handle, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;
 		OC_DEBUG(5, "  handle data not found, idx = %x\n", mapi_req->handle_idx);
 		goto end;
 	}
+
+	/* With CreateMessage, the parent object may NOT BE the direct
+           parent folder of the message */
 	context_object = data;
 
 	folderID = mapi_req->u.mapi_CreateMessage.FolderId;
@@ -567,6 +582,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSaveChangesMessage(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *)private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_MESSAGE) {
@@ -654,6 +675,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRemoveAllRecipients(TALLOC_CTX *mem_ctx,
 	}
 
 	mapi_repl->handle_idx = mapi_req->handle_idx;
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
 
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *)private_data;
@@ -887,6 +914,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopModifyRecipients(TALLOC_CTX *mem_ctx,
 
 	mapi_repl->handle_idx = mapi_req->handle_idx;
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *)private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_MESSAGE) {
@@ -979,6 +1012,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopReloadCachedInformation(TALLOC_CTX *mem_ctx,
 	retval = mapi_handles_search(emsmdbp_ctx->handles_ctx, handle, &rec);
 	if (retval) {
 		mapi_repl->error_code = MAPI_E_NOT_FOUND;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1099,6 +1138,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSetMessageReadFlag(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;
@@ -1183,6 +1228,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetMessageStatus(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &folder_private_data);
 	if (retval) {
 		mapi_repl->error_code = retval;
@@ -1261,6 +1312,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetAttachmentTable(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1345,6 +1402,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenAttach(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1445,6 +1508,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateAttach(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1599,6 +1668,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenEmbeddedMessage(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
 		mapi_repl->error_code = ecNullObject;
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcnotif.c
+++ b/mapiproxy/servers/default/emsmdb/oxcnotif.c
@@ -87,6 +87,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRegisterNotification(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
         retval = mapi_handles_get_private_data(parent_rec, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;

--- a/mapiproxy/servers/default/emsmdb/oxcperm.c
+++ b/mapiproxy/servers/default/emsmdb/oxcperm.c
@@ -81,6 +81,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPermissionsTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval || !data) {
 		mapi_repl->error_code = MAPI_E_NOT_FOUND;
@@ -167,6 +173,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopModifyPermissions(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcprpt.c
+++ b/mapiproxy/servers/default/emsmdb/oxcprpt.c
@@ -103,6 +103,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesSpecific(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
         object = private_data;
 	if (!object) {
@@ -260,6 +266,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesAll(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = private_data;
 	if (!object) {
@@ -359,6 +371,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesList(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = private_data;
 	if (!object) {
@@ -432,6 +450,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSetProperties(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -565,6 +589,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopOpenStream(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -728,7 +758,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopReadStream(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	/* Step 2. Retrieve the stream object */
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* Step 3. Retrieve the stream object */
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *) private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_STREAM) {
@@ -737,7 +773,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopReadStream(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	/* Step 3. Return the data and update the position in the stream */
+	/* Step 4. Return the data and update the position in the stream */
 	buffer_size = mapi_req->u.mapi_ReadStream.ByteCount;
 	/* careful here, let's switch to idiot mode */
 	if (buffer_size == 0xBABE) {
@@ -806,6 +842,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopWriteStream(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -884,6 +926,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCommitStream(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *) private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_STREAM) {
@@ -954,6 +1002,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetStreamSize(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &private_data);
 	object = (struct emsmdbp_object *) private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_STREAM) {
@@ -1016,6 +1070,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSeekStream(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1105,6 +1165,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSetStreamSize(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1398,6 +1464,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCopyTo(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(0, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcstor.c
+++ b/mapiproxy/servers/default/emsmdb/oxcstor.c
@@ -73,7 +73,12 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	username = ldb_msg_find_attr_as_string(res->msgs[0], "sAMAccountName", NULL);
 	OPENCHANGE_RETVAL_IF(!username, ecUnknownUser, NULL);
 
-	/* Step 2. Init and or update the user mailbox (auto-provisioning) */
+	/* Step 2. Set the logon map */
+	emsmdbp_ctx->username = talloc_strdup(emsmdbp_ctx, username);
+	ret = mapi_logon_set(emsmdbp_ctx->logon_ctx, mapi_req->logon_id, username);
+	OPENCHANGE_RETVAL_IF(ret != MAPI_E_SUCCESS, ret, NULL);
+
+	/* Step 3. Init and or update the user mailbox (auto-provisioning) */
 	ret = emsmdbp_mailbox_provision(emsmdbp_ctx, username);
 	OPENCHANGE_RETVAL_IF(ret != MAPI_E_SUCCESS, MAPI_E_DISK_ERROR, NULL);
 	/* TODO: freebusy entry should be created only during freebusy lookups */
@@ -82,10 +87,10 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 		OPENCHANGE_RETVAL_IF(ret != MAPI_E_SUCCESS, MAPI_E_DISK_ERROR, NULL);
 	}
 
-	/* Step 3. Set LogonFlags */
+	/* Step 4. Set LogonFlags */
 	response->LogonFlags = request->LogonFlags;
 
-	/* Step 4. Build FolderIds list */
+	/* Step 5. Build FolderIds list */
 	openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_MAILBOX_ROOT, &response->LogonType.store_mailbox.Root);
 	openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_DEFERRED_ACTION, &response->LogonType.store_mailbox.DeferredAction);
 	openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_SPOOLER_QUEUE, &response->LogonType.store_mailbox.SpoolerQueue);
@@ -100,21 +105,21 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_VIEWS, &response->LogonType.store_mailbox.Views);
 	openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_SHORTCUTS, &response->LogonType.store_mailbox.Shortcuts);
 
-	/* Step 5. Set ResponseFlags */
+	/* Step 6. Set ResponseFlags */
 	response->LogonType.store_mailbox.ResponseFlags = ResponseFlags_Reserved;
 	if (username && emsmdbp_ctx->username && strcmp(username, emsmdbp_ctx->username) == 0) {
 		response->LogonType.store_mailbox.ResponseFlags |= ResponseFlags_OwnerRight | ResponseFlags_SendAsRight;
 	}
 
-	/* Step 6. Retrieve MailboxGuid */
+	/* Step 7. Retrieve MailboxGuid */
 	openchangedb_get_MailboxGuid(emsmdbp_ctx->oc_ctx, username, &response->LogonType.store_mailbox.MailboxGuid);
 
-	/* Step 7. Retrieve mailbox replication information */
+	/* Step 8. Retrieve mailbox replication information */
 	openchangedb_get_MailboxReplica(emsmdbp_ctx->oc_ctx, username,
 					&response->LogonType.store_mailbox.ReplId,
 					&response->LogonType.store_mailbox.ReplGUID);
 
-	/* Step 8. Set LogonTime both in openchange dispatcher database and reply */
+	/* Step 9. Set LogonTime both in openchange dispatcher database and reply */
 	t = time(NULL);
 	LogonTime = localtime(&t);
 	response->LogonType.store_mailbox.LogonTime.Seconds = LogonTime->tm_sec;
@@ -125,11 +130,11 @@ static enum MAPISTATUS RopLogon_Mailbox(TALLOC_CTX *mem_ctx,
 	response->LogonType.store_mailbox.LogonTime.Month = LogonTime->tm_mon + 1;
 	response->LogonType.store_mailbox.LogonTime.Year = LogonTime->tm_year + 1900;
 
-	/* Step 9. Retrieve GwartTime */
+	/* Step 10. Retrieve GwartTime */
 	unix_to_nt_time(&nttime, t);
 	response->LogonType.store_mailbox.GwartTime = nttime - 1000000;
 
-	/* Step 10. Set StoreState */
+	/* Step 11. Set StoreState */
 	response->LogonType.store_mailbox.StoreState = 0x0;
 
 	return MAPI_E_SUCCESS;
@@ -283,6 +288,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRelease(TALLOC_CTX *mem_ctx,
 	   struct mapistore_subscription_list	*el;*/
 	enum MAPISTATUS				retval;
 	uint32_t				handle;
+
+	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx->logon_user, MAPI_E_LOGON_FAILED, NULL);
 
 	handle = handles[request->handle_idx];
 #if 0
@@ -731,6 +738,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopLongTermIdFromId(TALLOC_CTX *mem_ctx,
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
 		goto end;
 	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;
@@ -835,6 +849,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopIdFromLongTermId(TALLOC_CTX *mem_ctx,
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
 		goto end;
 	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;

--- a/mapiproxy/servers/default/emsmdb/oxctabl.c
+++ b/mapiproxy/servers/default/emsmdb/oxctabl.c
@@ -85,6 +85,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSetColumns(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;
@@ -184,6 +190,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSortTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval) {
 		mapi_repl->error_code = retval;
@@ -245,7 +257,7 @@ end:
 
 
 /**
-   \details EcDoRpc SortTable (0x14) Rop. This operation establishes a
+   \details EcDoRpc Restrict (0x14) Rop. This operation establishes a
    filter for a table.
 
    \param mem_ctx pointer to the memory context
@@ -295,6 +307,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRestrict(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -407,6 +425,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopQueryRows(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -607,6 +631,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopQueryPosition(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval) {
 		OC_DEBUG(5, "  no private data or object is not a table");
@@ -680,6 +710,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSeekRow(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -801,6 +837,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 
@@ -1011,6 +1053,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopResetTable(TALLOC_CTX *mem_ctx,
 	if (retval) {
 		mapi_repl->error_code = ecNullObject;
 		OC_DEBUG(5, "  handle (%x) not found: %x\n", handle, mapi_req->handle_idx);
+		goto end;
+	}
+
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -186,6 +186,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSubmitMessage(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *)private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_MESSAGE) {
@@ -422,6 +428,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopTransportSend(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(rec, &private_data);
 	object = (struct emsmdbp_object *)private_data;
 	if (!object || object->type != EMSMDBP_OBJECT_MESSAGE) {
@@ -560,7 +572,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetTransportFolder(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-	/* Step 2. Search for the specified MessageClass substring within user mailbox */
+	/* Step 2. Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
+	/* Step 3. Search for the specified MessageClass substring within user mailbox */
 	retval = openchangedb_get_TransportFolder(emsmdbp_ctx->oc_ctx, object->object.mailbox->owner_username,
 						  &mapi_repl->u.mapi_GetTransportFolder.FolderId);
 	if (retval) {

--- a/mapiproxy/servers/default/emsmdb/oxorule.c
+++ b/mapiproxy/servers/default/emsmdb/oxorule.c
@@ -82,6 +82,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetRulesTable(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
+	/* Check we have a logon user */
+	if (!emsmdbp_ctx->logon_user) {
+		mapi_repl->error_code = MAPI_E_LOGON_FAILED;
+		goto end;
+	}
+
 	retval = mapi_handles_get_private_data(parent, &data);
 	if (retval) {
 		mapi_repl->error_code = MAPI_E_NOT_FOUND;

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -877,8 +877,7 @@ static void dcesrv_NspiResortRestriction(struct dcesrv_call_state *dce_call,
    \param mem_ctx pointer to the memory context
    \param r pointer to the NspiDNToMId request data
 
-   \note Only searches within configuration.ldb are supported at the
-   moment.
+   \note it searches in directory for the legacy DN
 
    \return MAPI_E_SUCCESS on success
  */

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.h
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.h
@@ -170,6 +170,20 @@ uint32_t		emsabp_property_get_ulPropTag(const char *);
 int			emsabp_property_is_ref(uint32_t);
 const char		*emsabp_property_get_ref_attr(uint32_t);
 
+
+/**
+   \details Derive data for prop_tag from the given data
+   It returns the same pointer if the data is not derived
+
+   \param mem_ctx pointer to the memory context if requires new dynamic memory
+   \param prop_tag property tag to update
+   \param data pointer to the pointer from where the data is derived
+
+   \return pointer to a valid derived data
+
+ */
+void                    *emsabp_property_derive(TALLOC_CTX *mem_ctx, uint32_t prop_tag, void *data);
+
 __END_DECLS
 
 #endif /* __DCESRV_EXCHANGE_NSP_H */

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -5,6 +5,8 @@
 
    Copyright (C) Julien Kerihuel 2006-2014.
    Copyright (C) Pauline Khun 2006.
+                 Jesus Garcia 2014-2015
+                 Javier Amor Garcia 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -447,11 +449,6 @@ _PUBLIC_ enum MAPISTATUS emsabp_PermanentEntryID_to_Binary_r(TALLOC_CTX *mem_ctx
    return the values of the property PidTagEntryId in the Ephemeral
    or Permanent Entry ID format
 
-
-   \note This implementation is at the moment limited to MAILUSER,
-   which means we arbitrary set PR_OBJECT_TYPE and PR_DISPLAY_TYPE
-   while we should have a generic method to fill these properties.
-
    \return Valid generic pointer on success, otherwise NULL
  */
 _PUBLIC_ void *emsabp_query(TALLOC_CTX *mem_ctx, struct emsabp_context *emsabp_ctx,
@@ -596,6 +593,9 @@ _PUBLIC_ void *emsabp_query(TALLOC_CTX *mem_ctx, struct emsabp_context *emsabp_c
 		OC_DEBUG(3, "Unsupported property type: 0x%x", (ulPropTag & 0xFFFF));
 		break;
 	}
+
+	/* Step 4. Adapt derived properties from stored value in AD */
+	data = emsabp_property_derive(mem_ctx, ulPropTag, data);
 
 	return data;
 }

--- a/mapiproxy/servers/default/nspi/emsabp_property.c
+++ b/mapiproxy/servers/default/nspi/emsabp_property.c
@@ -4,6 +4,9 @@
    EMSABP: Address Book Provider implementation
 
    Copyright (C) Julien Kerihuel 2009-2013.
+                 Kamen Mazdrashki 2014
+                 Javier Amor Garcia 2015
+                 Enrique J. Hernandez 2016
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -57,6 +60,7 @@ static const struct emsabp_property emsabp_property[] = {
 	{ PidTagAddressBookObjectGuid,		"objectGUID",		false,	NULL			},
 	{ PidTagObjectType,			"msExchRecipientTypeDetails",		false,	NULL			},
 	{ PidTagDisplayType,			"msExchRecipientDisplayType",		false,	NULL			},
+	{ PidTagDisplayTypeEx,			"msExchRecipientDisplayType",		false,	NULL			},
 	{ PidTagBusinessTelephoneNumber,	"telephoneNumber",	false,	NULL			},
 	{ PidTagOfficeLocation,			"physicalDeliveryOfficeName",	false,	NULL			},
 	{ 0,					NULL,			false,	NULL			}
@@ -195,4 +199,27 @@ _PUBLIC_ const char *emsabp_property_get_ref_attr(uint32_t ulPropTag)
 	}
 
 	return NULL;
+}
+
+_PUBLIC_ void* emsabp_property_derive(TALLOC_CTX *mem_ctx, uint32_t prop_tag, void *data)
+{
+	uint32_t *i_ret;
+	void *ret;
+
+	if (!data) return NULL;
+
+	switch (prop_tag) {
+	case PidTagDisplayTypeEx:
+		i_ret = talloc_zero(mem_ctx, uint32_t);
+		if (!i_ret) {
+			return data;
+		}
+		/* Only support local forest */
+		*i_ret =  (1 << 30) | (*((uint32_t *)data) & 0xFF);
+		ret = (void *)i_ret;
+		break;
+	default:
+		ret = data;
+	}
+	return ret;
 }

--- a/testsuite/libmapiproxy/logon_table.c
+++ b/testsuite/libmapiproxy/logon_table.c
@@ -1,0 +1,100 @@
+/*
+   OpenChange Unit Testing
+
+   OpenChange Project
+
+   Copyright (C) Enrique J. Hernández 2016
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testsuite.h"
+#include "testsuite_common.h"
+#include "mapiproxy/libmapiproxy/libmapiproxy.h"
+#include "libmapi/libmapi.h"
+
+static TALLOC_CTX *g_mem_ctx;
+
+
+// v Unit test ----------------------------------------------------------------
+
+START_TEST (test_search_and_set_logon) {
+	const char **username;
+	const char *USER_1 = "Penny", *USER_2 = "Wise";
+	enum MAPISTATUS retval;
+	struct mapi_logon_context *logon_ctx;
+
+	username = talloc_zero(g_mem_ctx, const char *);
+
+	logon_ctx = mapi_logon_init(g_mem_ctx);
+	ck_assert(logon_ctx != NULL);
+
+	retval = mapi_logon_search(logon_ctx, 0, username);
+	ck_assert(retval == MAPI_E_NOT_FOUND);
+
+	retval = mapi_logon_set(logon_ctx, 12, USER_1);
+	ck_assert(retval == MAPI_E_SUCCESS);
+
+	retval = mapi_logon_search(logon_ctx, 12, username);
+	ck_assert(retval == MAPI_E_SUCCESS);
+	ck_assert(strcmp(*username, USER_1) == 0);
+
+	retval = mapi_logon_search(logon_ctx, 0, username);
+	ck_assert(retval == MAPI_E_NOT_FOUND);
+
+	retval = mapi_logon_set(logon_ctx, 13, USER_2);
+	ck_assert(retval == MAPI_E_SUCCESS);
+
+	retval = mapi_logon_search(logon_ctx, 13, username);
+	ck_assert(retval == MAPI_E_SUCCESS);
+	ck_assert(strcmp(*username, USER_2) == 0);
+
+	retval = mapi_logon_set(logon_ctx, 12, USER_2);
+	ck_assert(retval == MAPI_E_SUCCESS);
+
+	retval = mapi_logon_search(logon_ctx, 12, username);
+	ck_assert(retval == MAPI_E_SUCCESS);
+	ck_assert(strcmp(*username, USER_2) == 0);
+
+	retval = mapi_logon_release(logon_ctx);
+	ck_assert(retval == MAPI_E_SUCCESS);
+} END_TEST
+
+
+// ^ Unit test ----------------------------------------------------------------
+
+// v Suite definition ---------------------------------------------------------
+
+static void logon_table_setup(void)
+{
+	g_mem_ctx = talloc_new(talloc_autofree_context());
+}
+
+static void logon_table_teardown(void)
+{
+	talloc_free(g_mem_ctx);
+}
+
+Suite *mapiproxy_logon_table_suite(void)
+{
+	Suite *s = suite_create("mapi logon");
+
+	TCase *tc = tcase_create("mapi logon interface");
+	tcase_add_unchecked_fixture(tc, logon_table_setup, logon_table_teardown);
+
+	tcase_add_test(tc, test_search_and_set_logon);
+
+	suite_add_tcase(s, tc);
+	return s;
+}

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -107,6 +107,7 @@ int main(int argc, const char *argv[])
 	srunner_add_suite(sr, mapiproxy_openchangedb_ldb_suite());
 	srunner_add_suite(sr, mapiproxy_openchangedb_multitenancy_mysql_suite());
 	srunner_add_suite(sr, mapiproxy_openchangedb_logger_suite());
+	srunner_add_suite(sr, mapiproxy_logon_table_suite());
 	/* libmapistore */
 	srunner_add_suite(sr, mapistore_namedprops_suite());
 	srunner_add_suite(sr, mapistore_namedprops_mysql_suite());

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -51,6 +51,7 @@ Suite *mapiproxy_openchangedb_mysql_suite(void);
 Suite *mapiproxy_openchangedb_ldb_suite(void);
 Suite *mapiproxy_openchangedb_multitenancy_mysql_suite(void);
 Suite *mapiproxy_openchangedb_logger_suite(void);
+Suite *mapiproxy_logon_table_suite(void);
 /* libmapistore */
 Suite *mapistore_namedprops_suite(void);
 Suite *mapistore_namedprops_mysql_suite(void);


### PR DESCRIPTION
Give support to distinguish between the logged user (the one provided in **Logon ROP**) and the authenticated user (the one authenticated in **EcDoConnectEx** and **EcDoConnect**) and store the logon table as explained in [MS-OXCROPS] 3.1.4.2 ADM.

It requires https://github.com/zentyal/sogo/pull/250 to work.