### PR TITLE
Do not abort unsupported property type

### DIFF
--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -1098,8 +1098,7 @@ static void *get_property_data(TALLOC_CTX *mem_ctx, uint32_t proptag, const char
 		data = (void *)long_array;
 		break;
 	default:
-		OC_DEBUG(0, "Property Type 0x%.4x not supported\n", (proptag & 0xFFFF));
-		abort();
+		OC_DEBUG(1, "Property Type %#.4x not supported", proptag & 0xFFFF);
 		return NULL;
 	}
 
@@ -1192,6 +1191,7 @@ static enum MAPISTATUS get_folder_property(TALLOC_CTX *parent_ctx,
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, mem_ctx);
 	// Transform string into the expected data type
 	*data = get_property_data(parent_ctx, proptag, value);
+	OPENCHANGE_RETVAL_IF(*data == NULL, MAPI_E_NOT_FOUND, mem_ctx);
 end:
 	talloc_free(mem_ctx);
 	return retval;
@@ -3758,6 +3758,7 @@ static enum MAPISTATUS message_get_property(TALLOC_CTX *parent_ctx,
 	if (value != NULL) {
 		// Transform string into the expected data type
 		*data = get_property_data(parent_ctx, proptag, value);
+		OPENCHANGE_RETVAL_IF(*data == NULL, MAPI_E_NOT_FOUND, mem_ctx);
 		retval = MAPI_E_SUCCESS;
 	}
 

--- a/mapiproxy/libmapiserver/libmapiserver.h
+++ b/mapiproxy/libmapiserver/libmapiserver.h
@@ -537,7 +537,76 @@ uint16_t libmapiserver_RopGetNamesFromIDs_size(struct EcDoRpc_MAPI_REPL *);
 uint16_t libmapiserver_RopGetPropertyIdsFromNames_size(struct EcDoRpc_MAPI_REPL *);
 uint16_t libmapiserver_RopDeletePropertiesNoReplicate_size(struct EcDoRpc_MAPI_REPL *);
 uint16_t libmapiserver_RopCopyTo_size(struct EcDoRpc_MAPI_REPL *);
-int libmapiserver_push_property(TALLOC_CTX *, uint32_t, const void *, DATA_BLOB *, uint8_t, uint8_t, uint8_t);
+
+/**
+   \details Add a property value to a DATA blob. This convenient
+   function should be used when creating a GetPropertiesSpecific reply
+   response blob.
+
+   \param mem_ctx pointer to the memory context
+   \param property the property tag which value is meant to be
+   appended to the blob
+   \param value generic pointer on the property value
+   \param blob the data blob the function uses to return the blob
+   \param layout whether values should be prefixed by a layout
+   \param flagged define if the properties are flagged or not
+   \param untyped Whether the property type was originally untyped or not
+   and in that case we will push the property type as well
+
+   \note blob.length must be set to 0 before this function is called
+   the first time. Also the function only supports a limited set of
+   property types at the moment.
+
+   \return 0 on success, -1 otherwise
+ */
+int libmapiserver_push_property(TALLOC_CTX *mem_ctx, uint32_t property,
+	const void *value, DATA_BLOB *blob, uint8_t layout, uint8_t flagged,
+	uint8_t untyped);
+
+/**
+   \details Add properties values to a DATA blob.
+
+   \param mem_ctx pointer to the memory context
+   \param num_props number of properties to push
+   \param properties array of property tags which values are meant to be
+   appended to the blob
+   \param value array with generic pointers on the properties values
+   \param retvals array of error codes for the properties to push
+   \param blob the data blob the function uses to return the blob
+   \param layout whether values should be prefixed by a layout
+   \param flagged define whether the properties are flagged or not
+   \param untyped Whether to push property type or not
+
+   \see libmapiserver_push_property
+ */
+void libmapiserver_push_properties(TALLOC_CTX *mem_ctx, size_t num_props,
+	enum MAPITAGS *properties, void **values, enum MAPISTATUS *retvals,
+	DATA_BLOB *blob, uint8_t layout, uint8_t flagged, bool untyped);
+
+/**
+   \details Add properties values to a DATA blob.
+
+   \param mem_ctx pointer to the memory context
+   \param num_props number of properties to push
+   \param properties array of property tags which values are meant to be
+   appended to the blob
+   \param value array with generic pointers on the properties values
+   \param retvals array of error codes for the properties to push
+   \param blob the data blob the function uses to return the blob
+   \param layout whether values should be prefixed by a layout
+   \param flagged define whether the properties are flagged or not
+   \param untyped Array of booleans whether to push each property type or not
+
+   \note retvals array will be check and if the value is different of
+   MAPI_E_SUCCESS the property will be pushed as an error
+
+   \see libmapiserver_push_property
+ */
+void libmapiserver_push_properties_with_untyped(TALLOC_CTX *mem_ctx,
+	size_t num_props, enum MAPITAGS *properties, void **values,
+	enum MAPISTATUS *retvals, DATA_BLOB *blob, uint8_t layout,
+	uint8_t flagged, bool *untyped);
+
 struct SRow *libmapiserver_ROP_request_to_properties(TALLOC_CTX *, void *, uint8_t);
 
 /* definitions from libmapiserver_oxcstor.c */

--- a/mapiproxy/libmapiserver/libmapiserver_oxcdata.c
+++ b/mapiproxy/libmapiserver/libmapiserver_oxcdata.c
@@ -259,9 +259,10 @@ _PUBLIC_ uint16_t libmapiserver_mapi_SPropValue_size(uint16_t cValues, struct ma
 			}
 			break;
 		default:
-			abort();
+			OC_DEBUG(1, "Property Type %#.4x not supported, imprecise size "
+			         "will be returned", lpProps[i].ulPropTag & 0xffff);
 		}
 	}
-	
+
 	return size;
 }

--- a/mapiproxy/libmapiserver/libmapiserver_oxcprpt.c
+++ b/mapiproxy/libmapiserver/libmapiserver_oxcprpt.c
@@ -523,11 +523,11 @@ _PUBLIC_ int libmapiserver_push_property(TALLOC_CTX *mem_ctx,
 		}
 		break;
 	default:
-		if (property != 0) {
-			OC_DEBUG(5, "unsupported type: %.4x", (property & 0xffff));
-			abort();
-		}
-		break;
+		if (!property) break;
+		OC_DEBUG(1, "Property type %#.4x not supported, value not "
+			 "pushed", property & 0xffff);
+		talloc_free(ndr);
+		return -1;
 	}
 end:
 	/* Step 4. Steal ndr context */

--- a/mapiproxy/libmapistore/mapistore_namedprops.c
+++ b/mapiproxy/libmapistore/mapistore_namedprops.c
@@ -223,9 +223,9 @@ _PUBLIC_ enum mapistore_error mapistore_namedprops_get_nameid_type(struct namedp
 	case PT_MV_BINARY:
 		break;
 	default:
-		OC_DEBUG(0, "%d is not a valid type for a named property (%.4x)",
-			  *propTypeP, propID);
-		abort();
+		OC_DEBUG(0, "Property type %#.4x not supported for a named "
+		         "property (%#.4x)", *propTypeP, propID);
+		return MAPISTORE_ERR_NOT_IMPLEMENTED;
 	}
 
 	return MAPISTORE_SUCCESS;

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -509,8 +509,6 @@ static int process_tablemodified_contentstable_notification(TALLOC_CTX *mem_ctx,
 	int				ret;
 	uint32_t			prop_idx;
 	int				flagged = 0;
-	uint32_t			property;
-	void				*data = NULL;
 	enum ndr_err_code		ndr_err_code;
 	struct ndr_push			*ndr;
 	char				*mapistoreURI = NULL;
@@ -587,17 +585,9 @@ static int process_tablemodified_contentstable_notification(TALLOC_CTX *mem_ctx,
 				}
 
 				/* Push properties */
-				for (prop_idx = 0; prop_idx < SPropTagArray.cValues; prop_idx++) {
-					property = SPropTagArray.aulPropTag[prop_idx];
-					retval = retvals[prop_idx];
-					if (retval == MAPI_E_NOT_FOUND) {
-						property = (property & 0xFFFF0000) + PT_ERROR;
-						data = &retval;
-					} else {
-						data = data_pointers[prop_idx];
-					}
-					libmapiserver_push_property(mem_ctx, property, data, &payload, flagged?PT_ERROR:0, flagged, 0);
-				}
+				libmapiserver_push_properties(mem_ctx, SPropTagArray.cValues,
+					SPropTagArray.aulPropTag, data_pointers, retvals,
+					&payload, flagged ? PT_ERROR : 0, flagged, 0);
 
 				reply.u.mapi_Notify.NotificationData.ContentsTableChange.ContentsTableChangeUnion.ContentsRowModifiedNotification.Columns = payload;
 				reply.u.mapi_Notify.NotificationData.ContentsTableChange.ContentsTableChangeUnion.ContentsRowModifiedNotification.ColumnsSize = payload.length;

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -579,9 +579,9 @@ static int process_tablemodified_contentstable_notification(TALLOC_CTX *mem_ctx,
 
 				memset(&payload, 0, sizeof(DATA_BLOB));
 				if (flagged) {
-					libmapiserver_push_property(mem_ctx, 0xb, (const void *)&flagged, &payload, 0, 0, 0);
+					libmapiserver_push_property(mem_ctx, PT_BOOLEAN, (const void *)&flagged, &payload, 0, 0, 0);
 				} else {
-					libmapiserver_push_property(mem_ctx, 0x0, (const void *)&flagged, &payload, 0, 1, 0);
+					libmapiserver_push_property(mem_ctx, PT_UNSPECIFIED, (const void *)&flagged, &payload, 0, 1, 0);
 				}
 
 				/* Push properties */

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -2393,9 +2393,6 @@ _PUBLIC_ void emsmdbp_fill_table_row_blob(TALLOC_CTX *mem_ctx, struct emsmdbp_co
 {
         uint16_t i;
         uint8_t flagged;
-        enum MAPITAGS property;
-        void *data;
-        uint32_t retval;
 
         flagged = 0;
 
@@ -2416,21 +2413,9 @@ _PUBLIC_ void emsmdbp_fill_table_row_blob(TALLOC_CTX *mem_ctx, struct emsmdbp_co
                                             table_row, 0, 1, 0);
         }
 
-        for (i = 0; i < num_props; i++) {
-                property = properties[i];
-                retval = retvals[i];
-                if (retval != MAPI_E_SUCCESS) {
-                        property = (property & 0xFFFF0000) + PT_ERROR;
-                        data = &retval;
-                }
-                else {
-                        data = data_pointers[i];
-                }
-
-                libmapiserver_push_property(mem_ctx,
-                                            property, data, table_row,
-                                            flagged?PT_ERROR:0, flagged, 0);
-        }
+        libmapiserver_push_properties(mem_ctx, num_props, properties,
+                data_pointers, retvals, table_row, flagged ? PT_ERROR : 0,
+                flagged, 0);
 }
 
 /**
@@ -3560,9 +3545,6 @@ _PUBLIC_ void emsmdbp_fill_row_blob(TALLOC_CTX *mem_ctx,
 {
         uint16_t i;
         uint8_t flagged;
-        enum MAPITAGS property;
-        void *data;
-        uint32_t retval;
 
         flagged = 0;
         for (i = 0; !flagged && i < properties->cValues; i++) {
@@ -3572,20 +3554,9 @@ _PUBLIC_ void emsmdbp_fill_row_blob(TALLOC_CTX *mem_ctx,
         }
 	*layout = flagged;
 
-        for (i = 0; i < properties->cValues; i++) {
-                retval = retvals[i];
-                if (retval != MAPI_E_SUCCESS) {
-                        property = (properties->aulPropTag[i] & 0xFFFF0000) + PT_ERROR;
-                        data = &retval;
-                }
-                else {
-                        property = properties->aulPropTag[i];
-                        data = data_pointers[i];
-                }
-                libmapiserver_push_property(mem_ctx,
-                                            property, data, property_row,
-                                            flagged ? PT_ERROR : 0, flagged, untyped_status[i]);
-        }
+	libmapiserver_push_properties_with_untyped(mem_ctx, properties->cValues,
+		properties->aulPropTag, data_pointers, retvals, property_row,
+		flagged ? PT_ERROR : 0, flagged, untyped_status);
 }
 
 _PUBLIC_ struct emsmdbp_stream_data *emsmdbp_stream_data_from_value(TALLOC_CTX *mem_ctx, enum MAPITAGS prop_tag, void *value, bool read_write)

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -2403,13 +2403,12 @@ _PUBLIC_ void emsmdbp_fill_table_row_blob(TALLOC_CTX *mem_ctx, struct emsmdbp_co
         }
 
         if (flagged) {
-                libmapiserver_push_property(mem_ctx,
-                                            0x0000000b, (const void *)&flagged,
+                libmapiserver_push_property(mem_ctx, PT_BOOLEAN,
+                                            (const void *)&flagged,
                                             table_row, 0, 0, 0);
-        }
-        else {
-                libmapiserver_push_property(mem_ctx,
-                                            0x00000000, (const void *)&flagged,
+        } else {
+                libmapiserver_push_property(mem_ctx, PT_UNSPECIFIED,
+                                            (const void *)&flagged,
                                             table_row, 0, 1, 0);
         }
 

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -215,8 +215,7 @@ static void oxcfxics_ndr_push_simple_data(struct ndr_push *ndr, uint16_t prop_ty
 	case PT_NULL:
 		break;
 	default:
-		OC_DEBUG(5, "unsupported property type: %.4x\n", prop_type);
-		abort();
+		OC_DEBUG(1, "Property type %#.4x not supported, value not pushed", prop_type);
 	}
 }
 
@@ -249,8 +248,8 @@ static uint32_t oxcfxics_compute_cutmark_min_value_buffer(uint16_t prop_type)
 			min_value_buffer = 8;
 			break;
 		default:
-			OC_DEBUG(5, "unsupported property type: %.4x\n", prop_type);
-			abort();
+			OC_DEBUG(1, "Property type %#.4x not supported", prop_type);
+			min_value_buffer = 0;
 		}
 	}
 
@@ -342,8 +341,7 @@ static void oxcfxics_ndr_push_properties(struct ndr_push *ndr, struct ndr_push *
 					}
 					break;
 				default:
-					OC_DEBUG(5, "no handling for multi values of type %.4x\n", prop_type);
-					abort();
+					OC_DEBUG(1, "No handling for multivalues of type %#.4x", prop_type);
 				}
 			}
 			else {

--- a/mapiproxy/servers/default/emsmdb/oxcprpt.c
+++ b/mapiproxy/servers/default/emsmdb/oxcprpt.c
@@ -58,6 +58,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesSpecific(TALLOC_CTX *mem_ctx,
 {
 	TALLOC_CTX		*local_mem_ctx;
 	enum MAPISTATUS		retval;
+	enum mapistore_error	mapistore_retval;
 	struct GetProps_req	*request;
 	struct GetProps_repl	*response;
 	uint32_t		handle;
@@ -133,16 +134,15 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesSpecific(TALLOC_CTX *mem_ctx,
 			property_id = request->properties[i] >> 16;
 			if (property_id < 0x8000) {
 				property_type = get_property_type(property_id);
-			}
-			else {
-				property_type = 0;
-				mapistore_namedprops_get_nameid_type(emsmdbp_ctx->mstore_ctx->nprops_ctx, property_id, &property_type);
+			} else {
+				mapistore_retval = mapistore_namedprops_get_nameid_type(emsmdbp_ctx->mstore_ctx->nprops_ctx, property_id, &property_type);
+				if (mapistore_retval != MAPISTORE_SUCCESS)
+					property_type = 0;
 			}
 			if (property_type) {
 				properties->aulPropTag[i] |= property_type;
 				untyped_status[i] = true;
-			}
-			else {
+			} else {
 				properties->aulPropTag[i] |= PT_ERROR; /* fail with a MAPI_E_NOT_FOUND */
 				untyped_status[i] = false;
 			}

--- a/mapiproxy/servers/default/emsmdb/oxctabl.c
+++ b/mapiproxy/servers/default/emsmdb/oxctabl.c
@@ -861,13 +861,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 				}
 
 				if (flagged) {
-					libmapiserver_push_property(mem_ctx, 
-								    0x0000000b, (const void *)&flagged,
+					libmapiserver_push_property(mem_ctx, PT_BOOLEAN,
+								    (const void *)&flagged,
 								    &row, 0, 0, 0);
-				}
-				else {
-					libmapiserver_push_property(mem_ctx, 
-								    0x00000000, (const void *)&flagged,
+				} else {
+					libmapiserver_push_property(mem_ctx, PT_UNSPECIFIED,
+								    (const void *)&flagged,
 								    &row, 0, 1, 0);
 				}
 
@@ -918,13 +917,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 				}
 
 				if (flagged) {
-					libmapiserver_push_property(mem_ctx, 
-								    0x0000000b, (const void *)&flagged,
+					libmapiserver_push_property(mem_ctx, PT_BOOLEAN,
+								    (const void *)&flagged,
 								    &row, 0, 0, 0);
 				}
 				else {
-					libmapiserver_push_property(mem_ctx, 
-								    0x00000000, (const void *)&flagged,
+					libmapiserver_push_property(mem_ctx, PT_UNSPECIFIED,
+								    (const void *)&flagged,
 								    &row, 0, 1, 0);
 				}
 

--- a/mapiproxy/servers/default/emsmdb/oxctabl.c
+++ b/mapiproxy/servers/default/emsmdb/oxctabl.c
@@ -772,7 +772,6 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 	void				**data_pointers;
 	uint32_t			handle;
 	DATA_BLOB			row;
-	uint32_t			property;
 	uint8_t				flagged;
 	uint8_t				status = 0;
 	uint32_t			i;
@@ -871,27 +870,14 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 								    0x00000000, (const void *)&flagged,
 								    &row, 0, 1, 0);
 				}
-                                
-				/* Push the properties */
-				for (i = 0; i < table->prop_count; i++) {
-					property = table->properties[i];
-					retval = retvals[i];
-					if (retval == MAPI_E_NOT_FOUND) {
-						property = (property & 0xFFFF0000) + PT_ERROR;
-						data = &retval;
-					}
-					else {
-						data = data_pointers[i];
-					}
-                                
-					libmapiserver_push_property(mem_ctx,
-								    property, data, &row,
-								    flagged?PT_ERROR:0, flagged, 0);
-				}
+
+				libmapiserver_push_properties(mem_ctx, table->prop_count,
+					table->properties, data_pointers, retvals,
+					&row, flagged ? PT_ERROR : 0, flagged, 0);
+
 				talloc_free(retvals);
 				talloc_free(data_pointers);
-                        }
-                        else {
+			} else {
 				table->numerator++;
 			}
 		}
@@ -941,26 +927,14 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopFindRow(TALLOC_CTX *mem_ctx,
 								    0x00000000, (const void *)&flagged,
 								    &row, 0, 1, 0);
 				}
-                                
-				/* Push the properties */
-				for (i = 0; i < table->prop_count; i++) {
-					property = table->properties[i];
-					retval = retvals[i];
-					if (retval == MAPI_E_NOT_FOUND) {
-						property = (property & 0xFFFF0000) + PT_ERROR;
-						data = &retval;
-					}
-					else {
-						data = data_pointers[i];
-					}
-                                
-					libmapiserver_push_property(mem_ctx,
-								    property, data, &row,
-								    flagged?PT_ERROR:0, flagged, 0);
-				}
+
+				libmapiserver_push_properties(mem_ctx, table->prop_count,
+					table->properties, data_pointers, retvals,
+					&row, flagged ? PT_ERROR : 0, flagged, 0);
+
 				talloc_free(retvals);
 				talloc_free(data_pointers);
-                        } else {
+			} else {
 				table->numerator++;
 			}
 		}


### PR DESCRIPTION
Mostly refactorization. It only removes some `abort()` and now we will return error on those scenarios.